### PR TITLE
Added a TypeAlias class for simple type annotations

### DIFF
--- a/stubgen_pyx/convert.py
+++ b/stubgen_pyx/convert.py
@@ -158,7 +158,7 @@ class Annotation(Convertable):
 @dataclass
 class TypeAlias(Convertable):
     """
-    Simple type annotation.
+    Simple type alias (e.g. `Number = Union[int, float]`).
     """
 
     name: str


### PR DESCRIPTION
Previously it would not include lines like `Number = Union[int, float]` due to Union being a typing class which is not in the same module. This ignore meant that everything using that type variable was confused.

I changed it so it can also continue if the object comes from the typing class but is not in the typing namespace - which means it's a user created thing. I also added a TypeAlias to make these operations to use `=`.