### PR TITLE
Feature/write to outdir only

### DIFF
--- a/stubgen_pyx/cli.py
+++ b/stubgen_pyx/cli.py
@@ -169,14 +169,7 @@ def main():
     if args.dry_run:
         logger.info("DRY RUN MODE - no files will be written")
 
-    results = stubgen.convert_glob(pyx_file_pattern)
-
-    # Handle output directory relocation if specified
-    if output_dir and not args.dry_run:
-        logger.info(f"Moving .pyi files to {output_dir}")
-        for result in results:
-            if result.success:
-                result.pyi_file.rename(output_dir / result.pyi_file.name)
+    results = stubgen.convert_glob(pyx_file_pattern, output_dir=output_dir)
 
     # Summary reporting
     successful_count = sum(1 for r in results if r.success)
@@ -193,3 +186,7 @@ def main():
         sys.exit(1)
     
     sys.exit(0)
+
+# This helps to execute in the development env
+if "__main__" == __name__:
+    main()

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -135,8 +135,11 @@ class StubgenPyx:
 
         logger.info(f"Found {len(pyx_files)} file(s) to convert")
 
-        for pyx_file in pyx_files:
-            result = self._convert_single_file(Path(pyx_file))
+        for pyx_path in (Path(_pyx_file) for _pyx_file in pyx_files):
+            pyi_path = (output_dir / pyx_path.with_suffix(".pyi").name
+                        if output_dir
+                        else None)
+            result = self._convert_single_file(pyx_path, pyi_path)
             results.append(result)
 
             if self.config.verbose or not result.success:

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -113,12 +113,15 @@ class StubgenPyx:
         content = self.builder.build_module(module)
         return postprocessing_pipeline(content, self.config, pyx_path).strip()
 
-    def convert_glob(self, pyx_file_pattern: str) -> list[ConversionResult]:
-        """
-        Converts a glob pattern of .pyx files to .pyi files.
+    def convert_glob(self, pyx_file_pattern: str,
+                     output_dir: Path | None = None) -> list[ConversionResult]:
+        """Converts a glob pattern of .pyx files to .pyi files.
 
         Args:
             pyx_file_pattern: Glob pattern for files to convert (e.g., "**/*.pyx")
+            output_dir: Path to the output directory where pyi files shall be
+                written. If None, the pyi files will be collocated next to each
+                corresponding pyx file.
 
         Returns:
             List of ConversionResult objects with status for each file

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -141,12 +141,15 @@ class StubgenPyx:
 
         return results
 
-    def _convert_single_file(self, pyx_file_path: Path) -> ConversionResult:
-        """
-        Convert a single .pyx file to .pyi format.
+    def _convert_single_file(self, pyx_file_path: Path,
+                             pyi_file_path: Path | None = None) -> ConversionResult:
+        """Convert a single .pyx file to .pyi format.
 
         Args:
-            pyx_file_path: Path to the .pyx file
+            pyx_file_path: Path to the input .pyx file
+            pyi_file_path: Path to the output .pyi file to produce
+                           If not specified, the output file will be collocated
+                           next to the input pyx file.
 
         Returns:
             ConversionResult with success status and any errors
@@ -184,9 +187,10 @@ class StubgenPyx:
             )
 
             # Write pyi file
-            pyi_file_path = pyx_file_path.with_suffix(".pyi")
+            pyi_file_path = pyi_file_path or pyx_file_path.with_suffix(".pyi")
             try:
                 pyi_file_path.write_text(pyi_content, encoding="utf-8")
+                logger.debug(f"Wrote pyi file: {pyi_file_path}")
             except IOError as e:
                 raise IOError(f"Failed to write {pyi_file_path}: {e}") from e
 


### PR DESCRIPTION
When using option `--output-dir`, output files are written to the 'source' directories, i.e. all the directories containing the input pyx files. Only after generating the outputs, they get moved to the output dir. 

This is unsafe and error prone as the source directory may be read-only and it is a bad practice in out-of-tree building processes.

The modifications proposed here fix the problem by making the conversion process directly write to the output directory when specified, without touching the source dir.
