### PR TITLE
Support single file output from cli

### DIFF
--- a/stubgen_pyx/__main__.py
+++ b/stubgen_pyx/__main__.py
@@ -1,0 +1,7 @@
+# This can be used to directly invoke the cli
+# $> python -m stubgen_pyx --help
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/stubgen_pyx/cli.py
+++ b/stubgen_pyx/cli.py
@@ -55,7 +55,8 @@ Examples:
 
     parser.add_argument(
         "--output-dir",
-        help="Directory to write .pyi files (default: same as source)",
+        help="Directory to write .pyi files (default: same as source). " \
+             "This options cannot be used with option '--output-file'.",
         type=Path,
         default=None,
     )
@@ -63,8 +64,9 @@ Examples:
     parser.add_argument(
         "--output-file",
         help="Path to a .pyi file. Use to generate a specific file. " \
-             "To use this option, the list of matching input files " \
-             "must contain a single file.",
+             "To use this option, the list of matching input pyx files " \
+             "must contain a single file. " \
+             "This options cannot be used with option '--output-file'.",
         type=Path,
         default=None,
     )

--- a/stubgen_pyx/cli.py
+++ b/stubgen_pyx/cli.py
@@ -7,7 +7,7 @@ import logging
 import sys
 from pathlib import Path
 
-from .stubgen import StubgenPyx
+from .stubgen import ConversionResult, StubgenPyx
 from .config import StubgenPyxConfig
 from ._version import __version__
 
@@ -134,11 +134,35 @@ Examples:
 
     return parser
 
+def _check_args(args: argparse.Namespace) -> bool:
+    """Check the arguments passed to the cli.
+
+    Return True iff the arguments are correct.
+    """
+    if (args.output_dir is not None and args.output_file is not None):
+        logger.error("Error: options '--output-dir' and '--output-file' cannot be used together")
+        return False
+
+    return True
+
+def _create_dir(path: Path, dry_run: bool=False):
+    """Create given directory if not already existing.
+
+    dry_run controls the actual creation.
+    """
+    if not path.exists():
+        if dry_run:
+            logger.info(f"Would create output directory: {path}")
+        else:
+            path.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Created output directory: {path}")
 
 def main():
     """Main entry point for stubgen-pyx."""
     parser = _create_parser()
     args = parser.parse_args()
+    if not _check_args(args):
+        sys.exit(1)
 
     # Setup logging
     log_level = logging.DEBUG if args.verbose else logging.INFO
@@ -162,33 +186,44 @@ def main():
         verbose=args.verbose,
     )
 
-    # Validate output directory
-    output_dir = None
-    if args.output_dir:
-        output_dir = Path(args.output_dir)
-        if not output_dir.exists():
-            if args.dry_run:
-                logger.info(f"Would create output directory: {output_dir}")
-            else:
-                output_dir.mkdir(parents=True, exist_ok=True)
-                logger.info(f"Created output directory: {output_dir}")
-
     # Build file pattern
     source_dir = Path(args.dir) if args.dir else Path(".")
     if args.file:
         pyx_file_pattern = str(source_dir / args.file)
     else:
         pyx_file_pattern = str(source_dir / "**" / "*.pyx")
-
     logger.debug(f"Using pattern: {pyx_file_pattern}")
 
     # Create converter and run
     stubgen = StubgenPyx(config=config)
 
+    # Check single-file mode if requested
+    pyx_files = tuple(stubgen.resolve_glob(pyx_file_pattern))
+    if (args.output_file is not None
+          and (_num := len(pyx_files)) != 1):
+        logger.error(f"Option --output-file requires a single pyx file in input: {_num} found")
+        sys.exit(1)
+
+    # Validate output directory
+    output_dir = None
+    if args.output_dir:
+        output_dir = Path(args.output_dir)
+        _create_dir(output_dir, args.dry_run)
+    elif args.output_file:
+        output_dir = Path(args.output_file).parent
+        _create_dir(output_dir, args.dry_run)
+
     if args.dry_run:
         logger.info("DRY RUN MODE - no files will be written")
 
-    results = stubgen.convert_glob(pyx_file_pattern, output_dir=output_dir)
+    results: list[ConversionResult]
+    if args.output_file is None:
+        # multi-files input
+        results = stubgen.convert_multiple_files(pyx_files, output_dir=output_dir)
+    else:
+        # single-file input
+        assert len(pyx_files) == 1
+        results = [stubgen.convert_single_file(pyx_files[0], args.output_file)]
 
     # Summary reporting
     successful_count = sum(1 for r in results if r.success)

--- a/stubgen_pyx/cli.py
+++ b/stubgen_pyx/cli.py
@@ -134,17 +134,6 @@ Examples:
 
     return parser
 
-def _check_args(args: argparse.Namespace) -> bool:
-    """Check the arguments passed to the cli.
-
-    Return True iff the arguments are correct.
-    """
-    if (args.output_dir is not None and args.output_file is not None):
-        logger.error("Error: options '--output-dir' and '--output-file' cannot be used together")
-        return False
-
-    return True
-
 def _create_dir(path: Path, dry_run: bool=False):
     """Create given directory if not already existing.
 
@@ -157,11 +146,22 @@ def _create_dir(path: Path, dry_run: bool=False):
             path.mkdir(parents=True, exist_ok=True)
             logger.info(f"Created output directory: {path}")
 
-def main():
-    """Main entry point for stubgen-pyx."""
+def _parse_args() -> argparse.Namespace | None:
     parser = _create_parser()
     args = parser.parse_args()
-    if not _check_args(args):
+
+    # check the arguments
+    if (args.output_dir is not None and args.output_file is not None):
+        logger.error("Error: options '--output-dir' and '--output-file' cannot be used together")
+        return None
+
+    return args
+
+def main():
+    """Main entry point for stubgen-pyx."""
+
+    args = _parse_args()
+    if args is None:
         sys.exit(1)
 
     # Setup logging
@@ -200,8 +200,9 @@ def main():
     # Check single-file mode if requested
     pyx_files = tuple(stubgen.resolve_glob(pyx_file_pattern))
     if (args.output_file is not None
-          and (_num := len(pyx_files)) != 1):
-        logger.error(f"Option --output-file requires a single pyx file in input: {_num} found")
+          and ((_num := len(pyx_files)) != 1)):
+        logger.error("Option --output-file requires a single input pyx file in "
+                     f"'{pyx_file_pattern}': {_num} found")
         sys.exit(1)
 
     # Validate output directory

--- a/stubgen_pyx/cli.py
+++ b/stubgen_pyx/cli.py
@@ -21,11 +21,13 @@ def _create_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s .                        # Convert all .pyx files in current directory
-  %(prog)s src/ --file "**/*.pyx"   # Convert all .pyx files in src/
-  %(prog)s . --output-dir stubs/    # Write stubs to stubs/ directory
-  %(prog)s . --dry-run              # Preview conversions without writing
-  %(prog)s . --verbose              # Show detailed processing information
+  %(prog)s .                         # Convert all .pyx files in current directory
+  %(prog)s src/ --file "**/*.pyx"    # Convert all .pyx files in src/
+  %(prog)s . --output-dir stubs/     # Write stubs to stubs/ directory
+  %(prog)s . --dry-run               # Preview conversions without writing
+  %(prog)s . --verbose               # Show detailed processing information
+  %(prog)s src/ --file in.pyx --output-file out/out.pyi  # Convert a single pyx
+                                                         # file to an output file
         """,
     )
 
@@ -54,6 +56,15 @@ Examples:
     parser.add_argument(
         "--output-dir",
         help="Directory to write .pyi files (default: same as source)",
+        type=Path,
+        default=None,
+    )
+
+    parser.add_argument(
+        "--output-file",
+        help="Path to a .pyi file. Use to generate a specific file. " \
+             "To use this option, the list of matching input files " \
+             "must contain a single file.",
         type=Path,
         default=None,
     )

--- a/stubgen_pyx/cli.py
+++ b/stubgen_pyx/cli.py
@@ -220,11 +220,13 @@ def main():
     results: list[ConversionResult]
     if args.output_file is None:
         # multi-files input
-        results = stubgen.convert_multiple_files(pyx_files, output_dir=output_dir)
+        results = stubgen.convert_multiple_files(pyx_files, output_dir=output_dir,
+                                                 dry_run=args.dry_run)
     else:
         # single-file input
         assert len(pyx_files) == 1
-        results = [stubgen.convert_single_file(pyx_files[0], args.output_file)]
+        results = [stubgen.convert_single_file(pyx_files[0], args.output_file,
+                                               dry_run=args.dry_run)]
 
     # Summary reporting
     successful_count = sum(1 for r in results if r.success)

--- a/stubgen_pyx/cli.py
+++ b/stubgen_pyx/cli.py
@@ -205,8 +205,3 @@ def main():
         sys.exit(1)
 
     sys.exit(0)
-
-
-# This helps to execute in the development env
-if "__main__" == __name__:
-    main()

--- a/stubgen_pyx/cli.py
+++ b/stubgen_pyx/cli.py
@@ -55,18 +55,18 @@ Examples:
 
     parser.add_argument(
         "--output-dir",
-        help="Directory to write .pyi files (default: same as source). " \
-             "This options cannot be used with option '--output-file'.",
+        help="Directory to write .pyi files (default: same as source). "
+        "This option cannot be used with option '--output-file'.",
         type=Path,
         default=None,
     )
 
     parser.add_argument(
         "--output-file",
-        help="Path to a .pyi file. Use to generate a specific file. " \
-             "To use this option, the list of matching input pyx files " \
-             "must contain a single file. " \
-             "This options cannot be used with option '--output-file'.",
+        help="Path to a .pyi file. Use to generate a specific file. "
+        "To use this option, the list of matching input pyx files "
+        "must contain a single file. "
+        "This option cannot be used with option '--output-dir'.",
         type=Path,
         default=None,
     )
@@ -134,7 +134,8 @@ Examples:
 
     return parser
 
-def _create_dir(path: Path, dry_run: bool=False):
+
+def _create_dir(path: Path, dry_run: bool = False):
     """Create given directory if not already existing.
 
     dry_run controls the actual creation.
@@ -146,16 +147,20 @@ def _create_dir(path: Path, dry_run: bool=False):
             path.mkdir(parents=True, exist_ok=True)
             logger.info(f"Created output directory: {path}")
 
+
 def _parse_args() -> argparse.Namespace | None:
     parser = _create_parser()
     args = parser.parse_args()
 
     # check the arguments
-    if (args.output_dir is not None and args.output_file is not None):
-        logger.error("Error: options '--output-dir' and '--output-file' cannot be used together")
+    if args.output_dir is not None and args.output_file is not None:
+        logger.error(
+            "Error: options '--output-dir' and '--output-file' cannot be used together"
+        )
         return None
 
     return args
+
 
 def main():
     """Main entry point for stubgen-pyx."""
@@ -199,10 +204,11 @@ def main():
 
     # Check single-file mode if requested
     pyx_files = tuple(stubgen.resolve_glob(pyx_file_pattern))
-    if (args.output_file is not None
-          and ((_num := len(pyx_files)) != 1)):
-        logger.error("Option --output-file requires a single input pyx file in "
-                     f"'{pyx_file_pattern}': {_num} found")
+    if args.output_file is not None and ((_num := len(pyx_files)) != 1):
+        logger.error(
+            "Option --output-file requires a single input pyx file in "
+            f"'{pyx_file_pattern}': {_num} found"
+        )
         sys.exit(1)
 
     # Validate output directory
@@ -220,13 +226,17 @@ def main():
     results: list[ConversionResult]
     if args.output_file is None:
         # multi-files input
-        results = stubgen.convert_multiple_files(pyx_files, output_dir=output_dir,
-                                                 dry_run=args.dry_run)
+        results = stubgen.convert_multiple_files(
+            pyx_files, output_dir=output_dir, dry_run=args.dry_run
+        )
     else:
         # single-file input
         assert len(pyx_files) == 1
-        results = [stubgen.convert_single_file(pyx_files[0], args.output_file,
-                                               dry_run=args.dry_run)]
+        results = [
+            stubgen.convert_single_file(
+                pyx_files[0], args.output_file, dry_run=args.dry_run
+            )
+        ]
 
     # Summary reporting
     successful_count = sum(1 for r in results if r.success)

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import glob
 import logging
+from typing import Iterable
 from pathlib import Path
 
 from .config import StubgenPyxConfig
@@ -126,9 +127,29 @@ class StubgenPyx:
         content = self.builder.build_module(module)
         return postprocessing_pipeline(content, self.config, pyx_path).strip()
 
-    def convert_glob(
-        self, pyx_file_pattern: str, output_dir: Path | None = None
-    ) -> list[ConversionResult]:
+    def resolve_glob(self, pyx_file_pattern: str) -> Iterable[Path]:
+        """Resolve given glob pattern.
+
+        Args:
+            pyx_file_pattern: Glob pattern (e.g., "**/*.pyx", "src/*.pyx").
+
+        Returns:
+            Iterable of Path to the resolved file names
+        """
+
+        # Note: Path.glob is not suitable with patterns containing absolute
+        # paths, so glob is much better here
+        pyx_files = glob.glob(pyx_file_pattern, recursive=True)
+
+        if len(pyx_files) == 0:
+            logger.warning(f"No files matched pattern: {pyx_file_pattern}")
+        else:
+            logger.info(f"Found {len(pyx_files)} file(s) to convert")
+        return (Path(p) for p in pyx_files)
+
+    def convert_glob(self, pyx_file_pattern: str,
+                     output_dir: Path | None = None) \
+                     -> list[ConversionResult]:
         """Convert multiple .pyx files matching a glob pattern.
 
         Args:
@@ -139,20 +160,32 @@ class StubgenPyx:
         Returns:
             List of ConversionResult objects with status for each file.
         """
-        pyx_files = glob.glob(pyx_file_pattern, recursive=True)
+        pyx_files = self.resolve_glob(pyx_file_pattern)
+        return self.convert_multiple_files(pyx_files, output_dir=output_dir)
+
+    def convert_multiple_files(
+        self, pyx_file_paths: Iterable[Path], output_dir: Path | None = None
+    ) -> list[ConversionResult]:
+        """Convert multiple .pyx files, each possibly merging a companion .pxd file.
+
+        Reads the .pyx files and companions .pxd (if they exist), converts them,
+        and writes the resulting .pyi file.
+
+        Args:
+            pyx_file_paths: Paths to the input .pyx files.
+            output_dir: Optional output directory for .pyi files. If None,
+                .pyi files are placed next to their source files.
+
+        Returns:
+            ConversionResult with success status and any error details.
+        """
         results: list[ConversionResult] = []
 
-        if not pyx_files:
-            logger.warning(f"No files matched pattern: {pyx_file_pattern}")
-            return results
-
-        logger.info(f"Found {len(pyx_files)} file(s) to convert")
-
-        for pyx_path in (Path(_pyx_file) for _pyx_file in pyx_files):
+        for pyx_path in pyx_file_paths:
             pyi_path = (
                 output_dir / pyx_path.with_suffix(".pyi").name if output_dir else None
             )
-            result = self._convert_single_file(pyx_path, pyi_path)
+            result = self.convert_single_file(pyx_path, pyi_path)
             results.append(result)
 
             if self.config.verbose or not result.success:
@@ -160,7 +193,8 @@ class StubgenPyx:
 
         return results
 
-    def _convert_single_file(
+
+    def convert_single_file(
         self, pyx_file_path: Path, pyi_file_path: Path | None = None
     ) -> ConversionResult:
         """Convert a single .pyx file, optionally merging a companion .pxd file.

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -148,23 +148,28 @@ class StubgenPyx:
         return (Path(p) for p in pyx_files)
 
     def convert_glob(self, pyx_file_pattern: str,
-                     output_dir: Path | None = None) \
-                     -> list[ConversionResult]:
+                     output_dir: Path | None = None,
+                     dry_run: bool = False,
+                     ) -> list[ConversionResult]:
         """Convert multiple .pyx files matching a glob pattern.
 
         Args:
             pyx_file_pattern: Glob pattern (e.g., "**/*.pyx", "src/*.pyx").
             output_dir: Optional output directory for .pyi files. If None,
                 .pyi files are placed next to their source files.
+            dry_run: If True, no files are actually created.
 
         Returns:
             List of ConversionResult objects with status for each file.
         """
         pyx_files = self.resolve_glob(pyx_file_pattern)
-        return self.convert_multiple_files(pyx_files, output_dir=output_dir)
+        return self.convert_multiple_files(pyx_files, output_dir=output_dir,
+                                           dry_run=dry_run)
 
     def convert_multiple_files(
-        self, pyx_file_paths: Iterable[Path], output_dir: Path | None = None
+            self, pyx_file_paths: Iterable[Path],
+            output_dir: Path | None = None,
+            dry_run: bool = False,
     ) -> list[ConversionResult]:
         """Convert multiple .pyx files, each possibly merging a companion .pxd file.
 
@@ -175,6 +180,7 @@ class StubgenPyx:
             pyx_file_paths: Paths to the input .pyx files.
             output_dir: Optional output directory for .pyi files. If None,
                 .pyi files are placed next to their source files.
+            dry_run: If True, no files are actually created.
 
         Returns:
             ConversionResult with success status and any error details.
@@ -185,7 +191,7 @@ class StubgenPyx:
             pyi_path = (
                 output_dir / pyx_path.with_suffix(".pyi").name if output_dir else None
             )
-            result = self.convert_single_file(pyx_path, pyi_path)
+            result = self.convert_single_file(pyx_path, pyi_path, dry_run)
             results.append(result)
 
             if self.config.verbose or not result.success:
@@ -195,7 +201,8 @@ class StubgenPyx:
 
 
     def convert_single_file(
-        self, pyx_file_path: Path, pyi_file_path: Path | None = None
+            self, pyx_file_path: Path, pyi_file_path: Path | None = None,
+            dry_run: bool = False,
     ) -> ConversionResult:
         """Convert a single .pyx file, optionally merging a companion .pxd file.
 
@@ -206,12 +213,14 @@ class StubgenPyx:
             pyx_file_path: Path to the input .pyx file.
             pyi_file_path: Path to write the output .pyi file. If None,
                 defaults to the same location as the .pyx file with .pyi extension.
+            dry_run: If True, no files are actually created.
 
         Returns:
             ConversionResult with success status and any error details.
         """
+        pyi_file_path = pyi_file_path or pyx_file_path.with_suffix(".pyi")
         try:
-            logger.debug(f"Converting {pyx_file_path}")
+            logger.debug(f"Converting '{pyx_file_path}' to '{pyi_file_path}'")
 
             try:
                 pyx_str = pyx_file_path.read_text(encoding="utf-8")
@@ -239,12 +248,14 @@ class StubgenPyx:
                 pyx_path=pyx_file_path,
             )
 
-            pyi_file_path = pyi_file_path or pyx_file_path.with_suffix(".pyi")
-            try:
-                pyi_file_path.write_text(pyi_content, encoding="utf-8")
-                logger.debug(f"Wrote pyi file: {pyi_file_path}")
-            except IOError as e:
-                raise IOError(f"Failed to write {pyi_file_path}: {e}") from e
+            if not dry_run:
+                try:
+                    pyi_file_path.write_text(pyi_content, encoding="utf-8")
+                    logger.debug(f"Wrote pyi file: {pyi_file_path}")
+                except IOError as e:
+                    raise IOError(f"Failed to write {pyi_file_path}: {e}") from e
+            else:
+                logger.info(f"Would create output file: {pyi_file_path}")
 
             return ConversionResult(
                 success=True,
@@ -263,6 +274,6 @@ class StubgenPyx:
             return ConversionResult(
                 success=False,
                 pyx_file=pyx_file_path,
-                pyi_file=pyx_file_path.with_suffix(".pyi"),
+                pyi_file=pyi_file_path,
                 error=e,
             )

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -147,10 +147,12 @@ class StubgenPyx:
             logger.info(f"Found {len(pyx_files)} file(s) to convert")
         return (Path(p) for p in pyx_files)
 
-    def convert_glob(self, pyx_file_pattern: str,
-                     output_dir: Path | None = None,
-                     dry_run: bool = False,
-                     ) -> list[ConversionResult]:
+    def convert_glob(
+        self,
+        pyx_file_pattern: str,
+        output_dir: Path | None = None,
+        dry_run: bool = False,
+    ) -> list[ConversionResult]:
         """Convert multiple .pyx files matching a glob pattern.
 
         Args:
@@ -163,13 +165,15 @@ class StubgenPyx:
             List of ConversionResult objects with status for each file.
         """
         pyx_files = self.resolve_glob(pyx_file_pattern)
-        return self.convert_multiple_files(pyx_files, output_dir=output_dir,
-                                           dry_run=dry_run)
+        return self.convert_multiple_files(
+            pyx_files, output_dir=output_dir, dry_run=dry_run
+        )
 
     def convert_multiple_files(
-            self, pyx_file_paths: Iterable[Path],
-            output_dir: Path | None = None,
-            dry_run: bool = False,
+        self,
+        pyx_file_paths: Iterable[Path],
+        output_dir: Path | None = None,
+        dry_run: bool = False,
     ) -> list[ConversionResult]:
         """Convert multiple .pyx files, each possibly merging a companion .pxd file.
 
@@ -199,10 +203,11 @@ class StubgenPyx:
 
         return results
 
-
     def convert_single_file(
-            self, pyx_file_path: Path, pyi_file_path: Path | None = None,
-            dry_run: bool = False,
+        self,
+        pyx_file_path: Path,
+        pyi_file_path: Path | None = None,
+        dry_run: bool = False,
     ) -> ConversionResult:
         """Convert a single .pyx file, optionally merging a companion .pxd file.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,7 +161,7 @@ class TestCreateParser:
         )
         assert args.dir == "src/"
         assert args.file == "**/*.pyx"
-        assert args.output_dir == None
+        assert args.output_dir is None
         assert args.output_file == Path("stubs/output.pyi")
         assert args.verbose is True
         assert args.dry_run is True
@@ -314,16 +314,20 @@ class TestMain:
         mock_stubgen.resolve_glob.return_value = [Path("input.pyx")]
         mock_stubgen.convert_single_file.return_value = mock_result
 
-        with patch.object(sys, "argv", ["stubgen-pyx", ".",
-                                        "--file", "*.pyx",
-                                        "--output-file", "out.pyi"]):
+        with patch.object(
+            sys,
+            "argv",
+            ["stubgen-pyx", ".", "--file", "*.pyx", "--output-file", "out.pyi"],
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 cli.main()
             assert exc_info.value.code == 0
 
     @patch("stubgen_pyx.cli.StubgenPyx")
     @patch("stubgen_pyx.cli.logging.basicConfig")
-    def test_main_single_file_mode_no_input_files(self, mock_logging, mock_stubgen_class):
+    def test_main_single_file_mode_no_input_files(
+        self, mock_logging, mock_stubgen_class
+    ):
         """Test main function with zero inputs and single output mode."""
         mock_stubgen = MagicMock()
         mock_stubgen_class.return_value = mock_stubgen
@@ -332,27 +336,59 @@ class TestMain:
         mock_stubgen.resolve_glob.return_value = []
         mock_stubgen.convert_single_file.return_value = mock_result
 
-        with patch.object(sys, "argv", ["stubgen-pyx", ".",
-                                        "--file", "*.pyx",
-                                        "--output-file", "out.pyi"]):
+        with patch.object(
+            sys,
+            "argv",
+            ["stubgen-pyx", ".", "--file", "*.pyx", "--output-file", "out.pyi"],
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 cli.main()
             assert exc_info.value.code == 1
 
     @patch("stubgen_pyx.cli.StubgenPyx")
     @patch("stubgen_pyx.cli.logging.basicConfig")
-    def test_main_single_file_mode_too_many_input_files(self, mock_logging, mock_stubgen_class):
+    def test_main_single_file_mode_too_many_input_files(
+        self, mock_logging, mock_stubgen_class
+    ):
         """Test main function with multiple inputs and single output mode."""
         mock_stubgen = MagicMock()
         mock_stubgen_class.return_value = mock_stubgen
         mock_result = MagicMock()
         mock_result.success = False
-        mock_stubgen.resolve_glob.return_value = [Path("input1.pyx"), Path("input2.pyx")]
+        mock_stubgen.resolve_glob.return_value = [
+            Path("input1.pyx"),
+            Path("input2.pyx"),
+        ]
         mock_stubgen.convert_single_file.return_value = mock_result
 
-        with patch.object(sys, "argv", ["stubgen-pyx", ".",
-                                        "--file", "*.pyx",
-                                        "--output-file", "out.pyi"]):
+        with patch.object(
+            sys,
+            "argv",
+            ["stubgen-pyx", ".", "--file", "*.pyx", "--output-file", "out.pyi"],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+            assert exc_info.value.code == 1
+
+    @patch("stubgen_pyx.cli.StubgenPyx")
+    @patch("stubgen_pyx.cli.logging.basicConfig")
+    def test_main_output_dir_and_output_file(self, mock_logging, mock_stubgen_class):
+        """Test main function with output dir and output file."""
+        mock_stubgen = MagicMock()
+        mock_stubgen_class.return_value = mock_stubgen
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_stubgen.resolve_glob.return_value = [
+            Path("input1.pyx"),
+            Path("input2.pyx"),
+        ]
+        mock_stubgen.convert_single_file.return_value = mock_result
+
+        with patch.object(
+            sys,
+            "argv",
+            ["stubgen-pyx", ".", "--output-dir", "out", "--output-file", "out.pyi"],
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 cli.main()
             assert exc_info.value.code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,12 @@ class TestCreateParser:
         args = parser.parse_args([".", "--output-dir", "stubs/"])
         assert args.output_dir == Path("stubs/")
 
+    def test_parser_with_output_file(self):
+        """Test parser with --output-file."""
+        parser = cli._create_parser()
+        args = parser.parse_args([".", "--output-file", "stubs/output.pyi"])
+        assert args.output_file == Path("stubs/output.pyi")
+
     def test_parser_with_verbose_flag(self):
         """Test parser with --verbose flag."""
         parser = cli._create_parser()
@@ -110,7 +116,7 @@ class TestCreateParser:
         args = parser.parse_args([])
         assert args.dir == "."
 
-    def test_parser_all_flags_combined(self):
+    def test_parser_all_flags_combined_1(self):
         """Test parser with multiple flags."""
         parser = cli._create_parser()
         args = parser.parse_args(
@@ -136,6 +142,33 @@ class TestCreateParser:
         assert args.no_trim_imports is True
         assert args.continue_on_error is True
 
+    def test_parser_all_flags_combined_2(self):
+        """Test parser with multiple flags."""
+        parser = cli._create_parser()
+        args = parser.parse_args(
+            [
+                "src/",
+                "--file",
+                "**/*.pyx",
+                "--output-file",
+                "stubs/output.pyi",
+                "-v",
+                "--dry-run",
+                "--no-sort-imports",
+                "--no-trim-imports",
+                "--continue-on-error",
+            ]
+        )
+        assert args.dir == "src/"
+        assert args.file == "**/*.pyx"
+        assert args.output_dir == None
+        assert args.output_file == Path("stubs/output.pyi")
+        assert args.verbose is True
+        assert args.dry_run is True
+        assert args.no_sort_imports is True
+        assert args.no_trim_imports is True
+        assert args.continue_on_error is True
+
 
 class TestMain:
     """Test the main function."""
@@ -148,7 +181,7 @@ class TestMain:
         mock_stubgen_class.return_value = mock_stubgen
         mock_result = MagicMock()
         mock_result.success = True
-        mock_stubgen.convert_glob.return_value = [mock_result]
+        mock_stubgen.convert_multiple_files.return_value = [mock_result]
 
         with patch.object(sys, "argv", ["stubgen-pyx", "."]):
             with pytest.raises(SystemExit) as exc_info:
@@ -163,7 +196,7 @@ class TestMain:
         mock_stubgen_class.return_value = mock_stubgen
         mock_result = MagicMock()
         mock_result.success = True
-        mock_stubgen.convert_glob.return_value = [mock_result]
+        mock_stubgen.convert_multiple_files.return_value = [mock_result]
 
         with patch.object(sys, "argv", ["stubgen-pyx", ".", "-v"]):
             with pytest.raises(SystemExit) as exc_info:
@@ -183,7 +216,7 @@ class TestMain:
         mock_stubgen_class.return_value = mock_stubgen
         mock_result = MagicMock()
         mock_result.success = True
-        mock_stubgen.convert_glob.return_value = [mock_result]
+        mock_stubgen.convert_multiple_files.return_value = [mock_result]
 
         with tempfile.TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "new_stubs"
@@ -203,7 +236,7 @@ class TestMain:
         mock_stubgen_class.return_value = mock_stubgen
         mock_result = MagicMock()
         mock_result.success = True
-        mock_stubgen.convert_glob.return_value = [mock_result]
+        mock_stubgen.convert_multiple_files.return_value = [mock_result]
 
         with patch.object(sys, "argv", ["stubgen-pyx", ".", "--dry-run"]):
             with pytest.raises(SystemExit) as exc_info:
@@ -218,7 +251,7 @@ class TestMain:
         mock_stubgen_class.return_value = mock_stubgen
         mock_result = MagicMock()
         mock_result.success = False
-        mock_stubgen.convert_glob.return_value = [mock_result]
+        mock_stubgen.convert_multiple_files.return_value = [mock_result]
 
         with patch.object(sys, "argv", ["stubgen-pyx", "."]):
             with pytest.raises(SystemExit) as exc_info:
@@ -231,7 +264,7 @@ class TestMain:
         """Test main function when no files are found."""
         mock_stubgen = MagicMock()
         mock_stubgen_class.return_value = mock_stubgen
-        mock_stubgen.convert_glob.return_value = []
+        mock_stubgen.convert_multiple_files.return_value = []
 
         with patch.object(sys, "argv", ["stubgen-pyx", "."]):
             with pytest.raises(SystemExit) as exc_info:
@@ -248,7 +281,7 @@ class TestMain:
         mock_result1.success = True
         mock_result2 = MagicMock()
         mock_result2.success = False
-        mock_stubgen.convert_glob.return_value = [mock_result1, mock_result2]
+        mock_stubgen.convert_multiple_files.return_value = [mock_result1, mock_result2]
 
         with patch.object(sys, "argv", ["stubgen-pyx", "."]):
             with pytest.raises(SystemExit) as exc_info:
@@ -263,9 +296,63 @@ class TestMain:
         mock_stubgen_class.return_value = mock_stubgen
         mock_result = MagicMock()
         mock_result.success = True
-        mock_stubgen.convert_glob.return_value = [mock_result]
+        mock_stubgen.convert_multiple_files.return_value = [mock_result]
 
         with patch.object(sys, "argv", ["stubgen-pyx", "src/", "--file", "*.pyx"]):
             with pytest.raises(SystemExit) as exc_info:
                 cli.main()
             assert exc_info.value.code == 0
+
+    @patch("stubgen_pyx.cli.StubgenPyx")
+    @patch("stubgen_pyx.cli.logging.basicConfig")
+    def test_main_single_file_mode(self, mock_logging, mock_stubgen_class):
+        """Test main function with single input and single output mode."""
+        mock_stubgen = MagicMock()
+        mock_stubgen_class.return_value = mock_stubgen
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_stubgen.resolve_glob.return_value = [Path("input.pyx")]
+        mock_stubgen.convert_single_file.return_value = mock_result
+
+        with patch.object(sys, "argv", ["stubgen-pyx", ".",
+                                        "--file", "*.pyx",
+                                        "--output-file", "out.pyi"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+            assert exc_info.value.code == 0
+
+    @patch("stubgen_pyx.cli.StubgenPyx")
+    @patch("stubgen_pyx.cli.logging.basicConfig")
+    def test_main_single_file_mode_no_input_files(self, mock_logging, mock_stubgen_class):
+        """Test main function with zero inputs and single output mode."""
+        mock_stubgen = MagicMock()
+        mock_stubgen_class.return_value = mock_stubgen
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_stubgen.resolve_glob.return_value = []
+        mock_stubgen.convert_single_file.return_value = mock_result
+
+        with patch.object(sys, "argv", ["stubgen-pyx", ".",
+                                        "--file", "*.pyx",
+                                        "--output-file", "out.pyi"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+            assert exc_info.value.code == 1
+
+    @patch("stubgen_pyx.cli.StubgenPyx")
+    @patch("stubgen_pyx.cli.logging.basicConfig")
+    def test_main_single_file_mode_too_many_input_files(self, mock_logging, mock_stubgen_class):
+        """Test main function with multiple inputs and single output mode."""
+        mock_stubgen = MagicMock()
+        mock_stubgen_class.return_value = mock_stubgen
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_stubgen.resolve_glob.return_value = [Path("input1.pyx"), Path("input2.pyx")]
+        mock_stubgen.convert_single_file.return_value = mock_result
+
+        with patch.object(sys, "argv", ["stubgen-pyx", ".",
+                                        "--file", "*.pyx",
+                                        "--output-file", "out.pyi"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+            assert exc_info.value.code == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -302,3 +302,95 @@ def test_convert_single_file_in_output_dir(temp_dir, temp_outdir):
     # Verify the .pyi file exist
     assert not pyx_file.with_suffix(".pyi").exists()
     assert pyi_file.exists()
+
+
+# ----
+def test_convert_multiple_files_dry_run(temp_dir):
+    """Test glob conversion with multiple files with dry run."""
+    pyx_files = [temp_dir / f"test{i}.pyx"
+                 for i in range(3)]
+
+    # prepare the input files
+    for i, pyx_file in enumerate(pyx_files):
+        pyx_file.write_text(f"def func{i}(): pass")
+
+    config = StubgenPyxConfig()
+    stubgen = StubgenPyx(config=config)
+
+    results = stubgen.convert_multiple_files(pyx_files, dry_run=True)
+
+    assert len(results) == len(pyx_files)
+    assert all(r.success for r in results)
+
+    # Verify all .pyi files do not exist
+    for pyx_file in pyx_files:
+        assert not pyx_file.with_suffix(".pyi").exists()
+
+
+def test_convert_multiple_files_in_output_dir_dry_run(temp_dir, temp_outdir):
+    """Test glob conversion with multiple files with dry run."""
+    pyx_files = [temp_dir / f"test{i}.pyx"
+                 for i in range(3)]
+
+    # prepare the input files
+    for i, pyx_file in enumerate(pyx_files):
+        pyx_file.write_text(f"def func{i}(): pass")
+
+    config = StubgenPyxConfig()
+    stubgen = StubgenPyx(config=config)
+
+    results = stubgen.convert_multiple_files(
+        pyx_files, output_dir=temp_outdir, dry_run=True)
+
+    assert len(results) == len(pyx_files)
+    assert all(r.success for r in results)
+
+    pyi_files = [temp_outdir / pyx_file.with_suffix(".pyi").name
+                 for pyx_file in pyx_files]
+
+    # Verify all .pyi files do not exist in output dir and NOT in source dir
+    for pyx_file, pyi_file in zip(pyx_files, pyi_files):
+        assert not pyi_file.exists()
+        assert not pyx_file.with_suffix(".pyi").exists()
+
+
+def test_convert_single_file_dry_run(temp_dir):
+    """Test glob conversion with a single files with dry run."""
+
+    # prepare the input file
+    pyx_file = temp_dir / "test1.pyx"
+    pyx_file.write_text(f"def func1(): pass")
+
+    config = StubgenPyxConfig()
+    stubgen = StubgenPyx(config=config)
+
+    # No already existing .pyi file
+    assert not pyx_file.with_suffix(".pyi").exists()
+
+    result = stubgen.convert_single_file(pyx_file, dry_run=True)
+    assert result.success
+
+    # Verify the .pyi file do not exist
+    assert not pyx_file.with_suffix(".pyi").exists()
+
+
+def test_convert_single_file_in_output_dir_dry_run(temp_dir, temp_outdir):
+    """Test glob conversion with a single files in output dir with dry run."""
+
+    # prepare the input file
+    pyx_file = temp_dir / "test1.pyx"
+    pyx_file.write_text(f"def func1(): pass")
+    pyi_file = temp_outdir / pyx_file.with_suffix(".pyi").name
+
+    config = StubgenPyxConfig()
+    stubgen = StubgenPyx(config=config)
+
+    # No already existing .pyi file
+    assert not pyi_file.exists()
+
+    result = stubgen.convert_single_file(pyx_file, pyi_file, dry_run=True)
+    assert result.success
+
+    # Verify the .pyi file do not exist
+    assert not pyx_file.with_suffix(".pyi").exists()
+    assert not pyi_file.exists()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -212,3 +212,93 @@ def test_convert_glob_multiple_files_in_output_dir(temp_dir, temp_outdir):
     for i in range(3):
         assert not (temp_dir / f"test{i}.pyi").exists()
         assert (temp_outdir / f"test{i}.pyi").exists()
+
+
+def test_convert_multiple_files(temp_dir):
+    """Test glob conversion with multiple files."""
+    pyx_files = [temp_dir / f"test{i}.pyx"
+                 for i in range(3)]
+
+    # prepare the input files
+    for i, pyx_file in enumerate(pyx_files):
+        pyx_file.write_text(f"def func{i}(): pass")
+
+    config = StubgenPyxConfig()
+    stubgen = StubgenPyx(config=config)
+
+    results = stubgen.convert_multiple_files(pyx_files)
+
+    assert len(results) == len(pyx_files)
+    assert all(r.success for r in results)
+
+    # Verify all .pyi files exist
+    for pyx_file in pyx_files:
+        assert pyx_file.with_suffix(".pyi").exists()
+
+
+def test_convert_multiple_files_in_output_dir(temp_dir, temp_outdir):
+    """Test glob conversion with multiple files."""
+    pyx_files = [temp_dir / f"test{i}.pyx"
+                 for i in range(3)]
+
+    # prepare the input files
+    for i, pyx_file in enumerate(pyx_files):
+        pyx_file.write_text(f"def func{i}(): pass")
+
+    config = StubgenPyxConfig()
+    stubgen = StubgenPyx(config=config)
+
+    results = stubgen.convert_multiple_files(pyx_files, output_dir=temp_outdir)
+
+    assert len(results) == len(pyx_files)
+    assert all(r.success for r in results)
+
+    pyi_files = [temp_outdir / pyx_file.with_suffix(".pyi").name
+                 for pyx_file in pyx_files]
+
+    # Verify all .pyi files exist in output dir and NOT in source dir
+    for pyx_file, pyi_file in zip(pyx_files, pyi_files):
+        assert pyi_file.exists()
+        assert not pyx_file.with_suffix(".pyi").exists()
+
+
+def test_convert_single_file(temp_dir):
+    """Test glob conversion with a single files."""
+
+    # prepare the input file
+    pyx_file = temp_dir / "test1.pyx"
+    pyx_file.write_text(f"def func1(): pass")
+
+    config = StubgenPyxConfig()
+    stubgen = StubgenPyx(config=config)
+
+    # No already existing .pyi file
+    assert not pyx_file.with_suffix(".pyi").exists()
+
+    result = stubgen.convert_single_file(pyx_file)
+    assert result.success
+
+    # Verify the .pyi file exist
+    assert pyx_file.with_suffix(".pyi").exists()
+
+
+def test_convert_single_file_in_output_dir(temp_dir, temp_outdir):
+    """Test glob conversion with a single files in output dir."""
+
+    # prepare the input file
+    pyx_file = temp_dir / "test1.pyx"
+    pyx_file.write_text(f"def func1(): pass")
+    pyi_file = temp_outdir / pyx_file.with_suffix(".pyi").name
+
+    config = StubgenPyxConfig()
+    stubgen = StubgenPyx(config=config)
+
+    # No already existing .pyi file
+    assert not pyi_file.exists()
+
+    result = stubgen.convert_single_file(pyx_file, pyi_file)
+    assert result.success
+
+    # Verify the .pyi file exist
+    assert not pyx_file.with_suffix(".pyi").exists()
+    assert pyi_file.exists()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -216,8 +216,7 @@ def test_convert_glob_multiple_files_in_output_dir(temp_dir, temp_outdir):
 
 def test_convert_multiple_files(temp_dir):
     """Test glob conversion with multiple files."""
-    pyx_files = [temp_dir / f"test{i}.pyx"
-                 for i in range(3)]
+    pyx_files = [temp_dir / f"test{i}.pyx" for i in range(3)]
 
     # prepare the input files
     for i, pyx_file in enumerate(pyx_files):
@@ -238,8 +237,7 @@ def test_convert_multiple_files(temp_dir):
 
 def test_convert_multiple_files_in_output_dir(temp_dir, temp_outdir):
     """Test glob conversion with multiple files."""
-    pyx_files = [temp_dir / f"test{i}.pyx"
-                 for i in range(3)]
+    pyx_files = [temp_dir / f"test{i}.pyx" for i in range(3)]
 
     # prepare the input files
     for i, pyx_file in enumerate(pyx_files):
@@ -253,8 +251,9 @@ def test_convert_multiple_files_in_output_dir(temp_dir, temp_outdir):
     assert len(results) == len(pyx_files)
     assert all(r.success for r in results)
 
-    pyi_files = [temp_outdir / pyx_file.with_suffix(".pyi").name
-                 for pyx_file in pyx_files]
+    pyi_files = [
+        temp_outdir / pyx_file.with_suffix(".pyi").name for pyx_file in pyx_files
+    ]
 
     # Verify all .pyi files exist in output dir and NOT in source dir
     for pyx_file, pyi_file in zip(pyx_files, pyi_files):
@@ -267,7 +266,7 @@ def test_convert_single_file(temp_dir):
 
     # prepare the input file
     pyx_file = temp_dir / "test1.pyx"
-    pyx_file.write_text(f"def func1(): pass")
+    pyx_file.write_text("def func1(): pass")
 
     config = StubgenPyxConfig()
     stubgen = StubgenPyx(config=config)
@@ -287,7 +286,7 @@ def test_convert_single_file_in_output_dir(temp_dir, temp_outdir):
 
     # prepare the input file
     pyx_file = temp_dir / "test1.pyx"
-    pyx_file.write_text(f"def func1(): pass")
+    pyx_file.write_text("def func1(): pass")
     pyi_file = temp_outdir / pyx_file.with_suffix(".pyi").name
 
     config = StubgenPyxConfig()
@@ -307,8 +306,7 @@ def test_convert_single_file_in_output_dir(temp_dir, temp_outdir):
 # ----
 def test_convert_multiple_files_dry_run(temp_dir):
     """Test glob conversion with multiple files with dry run."""
-    pyx_files = [temp_dir / f"test{i}.pyx"
-                 for i in range(3)]
+    pyx_files = [temp_dir / f"test{i}.pyx" for i in range(3)]
 
     # prepare the input files
     for i, pyx_file in enumerate(pyx_files):
@@ -329,8 +327,7 @@ def test_convert_multiple_files_dry_run(temp_dir):
 
 def test_convert_multiple_files_in_output_dir_dry_run(temp_dir, temp_outdir):
     """Test glob conversion with multiple files with dry run."""
-    pyx_files = [temp_dir / f"test{i}.pyx"
-                 for i in range(3)]
+    pyx_files = [temp_dir / f"test{i}.pyx" for i in range(3)]
 
     # prepare the input files
     for i, pyx_file in enumerate(pyx_files):
@@ -340,13 +337,15 @@ def test_convert_multiple_files_in_output_dir_dry_run(temp_dir, temp_outdir):
     stubgen = StubgenPyx(config=config)
 
     results = stubgen.convert_multiple_files(
-        pyx_files, output_dir=temp_outdir, dry_run=True)
+        pyx_files, output_dir=temp_outdir, dry_run=True
+    )
 
     assert len(results) == len(pyx_files)
     assert all(r.success for r in results)
 
-    pyi_files = [temp_outdir / pyx_file.with_suffix(".pyi").name
-                 for pyx_file in pyx_files]
+    pyi_files = [
+        temp_outdir / pyx_file.with_suffix(".pyi").name for pyx_file in pyx_files
+    ]
 
     # Verify all .pyi files do not exist in output dir and NOT in source dir
     for pyx_file, pyi_file in zip(pyx_files, pyi_files):
@@ -359,7 +358,7 @@ def test_convert_single_file_dry_run(temp_dir):
 
     # prepare the input file
     pyx_file = temp_dir / "test1.pyx"
-    pyx_file.write_text(f"def func1(): pass")
+    pyx_file.write_text("def func1(): pass")
 
     config = StubgenPyxConfig()
     stubgen = StubgenPyx(config=config)
@@ -379,7 +378,7 @@ def test_convert_single_file_in_output_dir_dry_run(temp_dir, temp_outdir):
 
     # prepare the input file
     pyx_file = temp_dir / "test1.pyx"
-    pyx_file.write_text(f"def func1(): pass")
+    pyx_file.write_text("def func1(): pass")
     pyi_file = temp_outdir / pyx_file.with_suffix(".pyi").name
 
     config = StubgenPyxConfig()


### PR DESCRIPTION
I made several modifications to the cli and the core top-level.

## Support for single-file modality
This enables the use of stubgen-pyx as a compiler that accepts a single pyx file and produce a single pyi file, where both input and output are explicit.
E.g.
```sh
$> stubgen-pyx --file ./input-path/input.pyx --output-file ./output-path/out.pyi
```

## Fix of dry run modality
This required to propagate dry-run option down to the top-level core to avoid creating output file(s).
