### PR TITLE
Visit `CDefExternNode`

### DIFF
--- a/stubgen_pyx/analysis/visitor.py
+++ b/stubgen_pyx/analysis/visitor.py
@@ -50,6 +50,16 @@ class ScopeVisitor(TreeVisitor):
         self.visitchildren(node)
         return node
 
+    def visit_CDefExternNode(self, node):
+        """Propagate visit from "cdef extern" nodes.
+
+        `cdef extern from "<header.h>"` allows for declaration of enumerations
+        to be wrapped when `cpdef enum` is used. Here visiting is propagated
+        down to the children to search for those enums.
+        """
+        self.visitchildren(node)
+        return node
+
     def visit_SingleAssignmentNode(self, node):
         """Collect non-import assignments."""
         if isinstance(node.rhs, ExprNodes.ImportNode):

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -14,7 +14,7 @@ from .conversion.converter import Converter
 from .builders.builder import Builder
 from .parsing.parser import parse_pyx, path_to_module_name
 from .postprocessing.pipeline import postprocessing_pipeline
-from .models.pyi_elements import PyiImport
+from .models.pyi_elements import PyiImport, PyiModule
 
 
 logger = logging.getLogger(__name__)
@@ -77,6 +77,26 @@ class StubgenPyx:
         Raises:
             Various exceptions from parsing, conversion, or building.
         """
+        module = self.compile_str_to_module(pyx_str, pxd_str, pyx_path)
+        content = self.builder.build_module(module)
+        return postprocessing_pipeline(content, self.config, pyx_path).strip()
+
+    def compile_str_to_module(
+        self, pyx_str: str, pxd_str: str | None = None, pyx_path: Path | None = None
+    ) -> PyiModule:
+        """Compile Cython source strings into a PyiModule
+
+        Args:
+            pyx_str: The source Cython code.
+            pxd_str: Optional companion .pxd file content to merge.
+            pyx_path: Optional file path for context and error messages.
+
+        Returns:
+            PyiModule instance as the result of the compilation.
+
+        Raises:
+            Various exceptions from parsing, conversion, or building.
+        """
         self.builder.include_private = self.config.include_private
 
         module_name = path_to_module_name(pyx_path) if pyx_path else None
@@ -124,8 +144,7 @@ class StubgenPyx:
             )
         )
 
-        content = self.builder.build_module(module)
-        return postprocessing_pipeline(content, self.config, pyx_path).strip()
+        return module
 
     def resolve_glob(self, pyx_file_pattern: str) -> Iterable[Path]:
         """Resolve given glob pattern.

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -9,6 +9,7 @@ from stubgen_pyx.models.pyi_elements import (
     PyiClass,
     PyiFunction,
     PyiScope,
+    PyiEnum,
 )
 from stubgen_pyx.parsing.parser import parse_pyx
 from stubgen_pyx.analysis.visitor import ModuleVisitor
@@ -408,3 +409,24 @@ cpdef enum Color:
         result = converter.convert_module(visitor, parsed.source)
 
         assert len(result.scope.enums) >= 1
+
+    def test_convert_enum_in_extern(self):
+        """Test converting enum with extern."""
+        code = """
+cdef extern from "<header.h>":
+    cpdef enum my_extern_enum:
+        MY_ENUM_V1
+        MY_ENUM_V2
+        MY_ENUM_V3
+"""
+        parsed = parse_pyx(code)
+        visitor = ModuleVisitor(parsed.source_ast)
+
+        converter = Converter()
+        result = converter.convert_module(visitor, parsed.source)
+
+        assert len(result.scope.enums) == 1
+        _enum = result.scope.enums[0]
+        assert isinstance(_enum, PyiEnum)
+        assert "my_extern_enum" == _enum.enum_name
+        assert "MY_ENUM_V1" in _enum.names

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -312,6 +312,46 @@ cdef enum Priority:
         # Should collect enums
         assert isinstance(visitor.enums, list)
 
+    def test_scope_visitor_multiple_enums_with_extern(self):
+        """Test collecting multiple enums, some extern"""
+        code = """
+cdef enum NotWrappedInternal:
+    V1 = 0
+    V2 = 1
+
+cpdef enum WrappedInternal:
+    V3 = 0
+    V4 = 1
+
+cdef extern from "<header.h>":
+    cdef enum NotWrappedExternal:
+        V5
+
+    cpdef enum WrappedExternal:
+        V6
+        V7
+"""
+        parsed = parse_pyx(code)
+        visitor = ScopeVisitor(parsed.source_ast)
+
+        # Should collect enums
+        assert isinstance(visitor.enums, list)
+        assert len(visitor.enums) == 4
+
+        assert all(e.name == exp_val
+                   for e, exp_val in zip(visitor.enums,
+                                         ["NotWrappedInternal", "WrappedInternal",
+                                          "NotWrappedExternal", "WrappedExternal"]))
+        for e, exp_val in zip(visitor.enums,
+                              ["private", "private",
+                               "extern", "extern"]):
+            assert e.visibility == exp_val
+
+        for e, exp_val in zip(visitor.enums,
+                              [False, True,
+                               False, True]):
+            assert e.create_wrapper == exp_val
+
 
 class TestImportVisitorBasics:
     """Test ImportVisitor with basic code."""


### PR DESCRIPTION
CDefExternNode are now visited to find and stub wrapped enums that are found in extern blocks.

Now can generate typing annotation into the output pyi that otherwise would be ignored.
For example:
```
...
cdef extern from "<header.h>":
    cpdef enum my_extern_enum:
        MY_ENUM_V1
        MY_ENUM_V2
        MY_ENUM_V3
...
```

... generates:

```
class my_extern_enum:
    MY_ENUM_V1: int
    MY_ENUM_V2: int
    MY_ENUM_V3: int
```