### PR TITLE
 Remove Cython dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "Cython>=3.0.11",
     "isort>=6.1.0",
 ]
 


### PR DESCRIPTION
Hey! First of all, thanks for creating this tool — it's really useful!

I was looking at the dependencies and noticed something interesting: **Cython isn't actually used anywhere in the code**. I went through the entire codebase carefully — not a single `import cython` or `from cython` anywhere.

The only real dependency is `isort` (which is a nice bonus for formatting).

**Why I'm asking for this:**

I'm using this package in CI/CD, and I'm pretty obsessive about package size. Every megabyte matters when you're building Docker images or running on limited CI runners.

Here's what the current size looks like:

```
$ pip-size stubgen-pyx
stubgen-pyx==0.2.4  33.3 KB  (total: 3.3 MB)
├── Cython==3.2.4  3.2 MB
└── isort==8.0.1  87.6 KB

$ pip-size pybind11-stubgen
pybind11-stubgen==2.5.5  29.5 KB
```

Compare that to the similar tool `pybind11-stubgen`: **29.5 KB with zero dependencies**! 

Removing Cython would drop stubgen-pyx from **3.3 MB to ~100 KB** — that's a huge difference, and would bring it much closer to its competitor's footprint.

**My suggestion:**

If there's a specific Cython version requirement or if older .pyx files aren't supported, I'd suggest documenting that in the README or in a "Limitations" section. That way users know what to expect, rather than having it hidden in pyproject.toml as an unused dependency.

**Changes:**
- Remove `Cython` from dependencies
- Keep `isort` (it's actually used)

Would love to see this merged! Thanks again for the tool 🙌