### PR TITLE
Don't include `cimport`s in generated stubs

### DIFF
--- a/stubgen_pyx/analysis/visitor.py
+++ b/stubgen_pyx/analysis/visitor.py
@@ -129,15 +129,11 @@ class ImportVisitor(TreeVisitor):
         self.visitchildren(node)
         return node
 
-    def visit_CImportNode(self, node):
-        """Visits cimport nodes."""
-        self.imports.append(node)
-        return node
-
-    def visit_CImportStatNode(self, node):
-        """Visits cimport statement nodes."""
-        self.imports.append(node)
-        return node
+    # NOTE: Cython `cimport`s (CImportNode, CImportStatNode,
+    # FromCImportStatNode) are intentionally NOT collected: they reference
+    # C-level declarations from .pxd files (libc, libcpp, cpython, cydriver,
+    # etc.) that are not Python-importable and therefore must not appear in
+    # generated .pyi stubs.
 
     def visit_ImportNode(self, node):
         """Visits import nodes."""
@@ -151,11 +147,6 @@ class ImportVisitor(TreeVisitor):
 
     def visit_FromImportStatNode(self, node):
         """Visits from...import statement nodes."""
-        self.imports.append(node)
-        return node
-
-    def visit_FromCImportStatNode(self, node):
-        """Visits from...cimport statement nodes."""
         self.imports.append(node)
         return node
 

--- a/stubgen_pyx/models/pyi_elements.py
+++ b/stubgen_pyx/models/pyi_elements.py
@@ -3,10 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-import re
-
-
-_IMPORT_RE = re.compile(r"\bcimport\b")
 
 
 @dataclass
@@ -60,10 +56,11 @@ class PyiAssignment(PyiStatement):
 
 @dataclass
 class PyiImport(PyiStatement):
-    """Represents an import statement. The `cimport` keyword is replaced with `import`."""
+    """Represents a Python import statement.
 
-    def __post_init__(self):
-        self.statement = _IMPORT_RE.sub("import", self.statement)
+    `cimport` statements are filtered upstream in the analysis visitor and
+    never reach this class.
+    """
 
 
 @dataclass

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -431,6 +431,30 @@ from cpython.mem cimport PyMem_Malloc
         # Should collect cimport statements
         assert isinstance(visitor.imports, list)
 
+    def test_import_visitor_cimports_are_filtered(self):
+        """`cimport`s reference C-level declarations from .pxd files and must
+        not appear in generated .pyi stubs. Verify they are filtered out and
+        that adjacent regular Python imports are still collected."""
+        code = """
+import os
+cimport cython
+from typing import List
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
+from .other cimport SomeCType
+import sys
+"""
+        parsed = parse_pyx(code)
+        visitor = ImportVisitor(parsed.source_ast)
+
+        rendered = [getattr(n, "module_name", None) or repr(n) for n in visitor.imports]
+        for entry in rendered:
+            assert "cython" != entry
+            assert "cpython.mem" != entry
+            assert ".other" != entry
+
+        # The three regular Python imports must still be present.
+        assert len(visitor.imports) == 3
+
 
 class TestModuleVisitorBasics:
     """Test ModuleVisitor with basic code."""
@@ -670,8 +694,9 @@ cdef enum Status:
         parsed = parse_pyx(code)
         module_visitor = ModuleVisitor(parsed.source_ast)
 
-        # Test imports
-        assert len(module_visitor.import_visitor.imports) >= 3
+        # Test imports — `cimport cython` is filtered out, so only the two
+        # regular Python imports remain.
+        assert len(module_visitor.import_visitor.imports) >= 2
 
         # Test scope
         assert len(module_visitor.scope.py_functions) >= 2


### PR DESCRIPTION
The current behavior of `stubgen-pyx` is to convert `cimport`s to `import`s and include them in the `.pyi` file.  The problem we are running into with this behavior is that most of what is `cimport`ed is not actually Python-exposed content, such as `cdef struct` or `cdef` functions etc.  When these get included in the `.pyi` file and then we try to check for type annotation consistency using `pyright` or `mypy`, these imports fail (since they point to things that aren't Python importable and can't be re-exposed publicly).  For our project, we would like to eventually get to something that is type check error-free, and this makes that challenging.

I realize this is a bit of a grey area for Cython.  It is possible to `cimport` an extension type, which /is/ runtime imported and is exposed to Python.  I think the only way for `stubgen-pyx` to tell the difference would be to actually resolve the `cimport` and see what it is.

I think it is better for users to use `import` for importing an extension type, which has (as far as I can tell) no behavioral difference, but makes it clear that the object is being imported for Python exposure.

There is [more information in this part of the docs](https://cython.readthedocs.io/en/latest/src/userguide/sharing_declarations.html#the-cimport-statement) particularly:

> It is important to understand that the [cimport](https://cython.readthedocs.io/en/latest/src/userguide/sharing_declarations.html#cimport) statement can only be used to import C data types, C functions and variables, and extension types. It cannot be used to import any Python objects, and (with one exception) it doesn’t imply any Python import at run time. If you want to refer to any Python names from a module that you have cimported, you will have to include a regular import statement for it as well.

>
> The exception is that when you use [cimport](https://cython.readthedocs.io/en/latest/src/userguide/sharing_declarations.html#cimport) to import an extension type, its type object is imported at run time and made available by the name under which you imported it.