### PR TITLE
Complete the set of integer-like types

### DIFF
--- a/stubgen_pyx/postprocessing/normalize_names.py
+++ b/stubgen_pyx/postprocessing/normalize_names.py
@@ -23,12 +23,16 @@ _CYTHON_INTS: tuple[str, ...] = (
     "size_t",
     "ssize_t",
     "ptrdiff_t",
-    "int64_t",
-    "int32_t",
+    "intptr_t",
+    "uintptr_t",
+    "int8_t",
     "int16_t",
-    "uint64_t",
-    "uint32_t",
+    "int32_t",
+    "int64_t",
+    "uint8_t",
     "uint16_t",
+    "uint32_t",
+    "uint64_t",
 )
 
 _CYTHON_FLOATS: tuple[str, ...] = (

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import ast
 
+import pytest
+
 from stubgen_pyx.postprocessing import (
     collect_names,
     deduplicate_imports,
@@ -279,6 +281,19 @@ class TestNormalizeNames:
         result_str = ast.unparse(result)
         assert "MyClass" in result_str
         assert "int" in result_str
+
+    @pytest.mark.parametrize(
+        "cython_type",
+        normalize_names._CYTHON_INTS
+    )
+    def test_normalize_cython_int_types(self, cython_type):
+        """Cython integer-like type names normalize to ``int``."""
+        code = f"def func(x: {cython_type}) -> {cython_type}: pass"
+        tree = ast.parse(code)
+        result = normalize_names.normalize_names(tree)
+        result_str = ast.unparse(result)
+        assert cython_type not in result_str
+        assert "def func(x: int) -> int" in result_str
 
 
 class TestSortImports:


### PR DESCRIPTION
There are a few extra integer-like types in `libc.stdint` that weren't covered here.