### PR TITLE
Exclude private variables

### DIFF
--- a/stubgen_pyx/builders/builder.py
+++ b/stubgen_pyx/builders/builder.py
@@ -135,6 +135,10 @@ class Builder:
 
     def build_assignment(self, assignment: PyiAssignment) -> str | None:
         """Build an assignment statement string."""
+        if not self.include_private:
+            name = assignment.statement.partition("=")[0].partition(":")[0].strip()
+            if self._is_private(name):
+                return None
         return assignment.statement
 
     def build_import(self, import_statement: PyiImport) -> str | None:

--- a/stubgen_pyx/builders/builder.py
+++ b/stubgen_pyx/builders/builder.py
@@ -92,6 +92,8 @@ class Builder:
         Returns:
             Class definition with docstring, decorators, bases, and body.
         """
+        if not self.include_private and self._is_private(class_.name):
+            return None
         output = "".join(f"{decorator}\n" for decorator in class_.decorators)
         output += f"class {class_.name}"
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -212,6 +212,25 @@ class TestBuilder:
         result = builder.build_assignment(assignment)
         assert result == "x: int = 5"
 
+    def test_build_assignment_private_excluded(self):
+        """Test that private assignments are excluded by default."""
+        builder = Builder(include_private=False)
+        assert builder.build_assignment(PyiAssignment("_x: int = 5")) is None
+        assert builder.build_assignment(PyiAssignment("_data = {...}")) is None
+        assert builder.build_assignment(PyiAssignment("_count = 42")) is None
+
+    def test_build_assignment_private_included(self):
+        """Test that private assignments are included when specified."""
+        builder = Builder(include_private=True)
+        result = builder.build_assignment(PyiAssignment("_x: int = 5"))
+        assert result == "_x: int = 5"
+
+    def test_build_assignment_dunder_not_private(self):
+        """Test that dunder assignments are not treated as private."""
+        builder = Builder(include_private=False)
+        result = builder.build_assignment(PyiAssignment("__all__ = ['x']"))
+        assert result == "__all__ = ['x']"
+
     def test_build_import_simple(self):
         """Test building a simple import statement."""
         builder = Builder()

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -291,6 +291,20 @@ class TestBuilder:
         assert result
         assert "@dataclass" in result
 
+    def test_build_class_private_excluded(self):
+        """Test that private classes are excluded by default."""
+        builder = Builder(include_private=False)
+        cls = PyiClass(name="_PrivateClass", scope=PyiScope())
+        assert builder.build_class(cls) is None
+
+    def test_build_class_private_included(self):
+        """Test that private classes are included when specified."""
+        builder = Builder(include_private=True)
+        cls = PyiClass(name="_PrivateClass", scope=PyiScope())
+        result = builder.build_class(cls)
+        assert result
+        assert "class _PrivateClass" in result
+
     def test_build_scope_with_assignments(self):
         """Test building a scope with assignments."""
         builder = Builder()


### PR DESCRIPTION
This extends the existing filtering of private functions to private variables (assignments) and classes.

I know Cython has better ways to make things really private.  In CUDA core we often expose "private by convention" things to make testing from pure Python easier, so it's nice to have them but exclude them from public API.