### PR TITLE
Pass along `# type: ...` annotation comments

### DIFF
--- a/stubgen_pyx/builders/builder.py
+++ b/stubgen_pyx/builders/builder.py
@@ -128,11 +128,15 @@ class Builder:
         if not self.include_private and self._is_private(function.name):
             return None
         output = "".join(f"{decorator}\n" for decorator in function.decorators)
-        output += f"{'async ' if function.is_async else ''}def {function.name}{self.build_signature(function.signature)}: "
+        output += f"{'async ' if function.is_async else ''}def {function.name}{self.build_signature(function.signature)}:"
+        if function.type_comment:
+            output += f"  {function.type_comment}"
         if function.doc is not None:
             output += f"\n{textwrap.indent(function.doc, '    ')}"
+        elif function.type_comment:
+            output += "\n    ..."
         else:
-            output += "..."
+            output += " ..."
         return output
 
     def build_assignment(self, assignment: PyiAssignment) -> str | None:

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -5,7 +5,7 @@ Converts Cython AST nodes to PyiElements.
 from __future__ import annotations
 import ast
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from Cython.Compiler import Nodes
 
@@ -39,6 +39,11 @@ class Converter:
     Transforms Cython Compiler AST nodes (as collected by visitors) into
     intermediate PyiElement representations for building .pyi stub files.
     """
+
+    type_comments: dict[int, str] = field(default_factory=dict)
+
+    def _type_comment_for(self, node: Nodes.Node) -> str | None:
+        return self.type_comments.get(node.pos[1])
 
     def convert_module(self, visitor: ModuleVisitor, source_code: str) -> PyiModule:
         """Convert a ModuleVisitor to a PyiModule.
@@ -133,6 +138,7 @@ class Converter:
             doc=doc,
             decorators=get_decorators(source_code, cdef_func),
             signature=get_signature(cdef_func),
+            type_comment=self._type_comment_for(cdef_func),
         )
 
     def convert_py_func(self, node: Nodes.DefNode, source_code: str) -> PyiFunction:
@@ -145,6 +151,7 @@ class Converter:
             doc=doc,
             decorators=get_decorators(source_code, node),
             signature=get_signature(node),
+            type_comment=self._type_comment_for(node),
         )
 
     def convert_assignment(

--- a/stubgen_pyx/models/pyi_elements.py
+++ b/stubgen_pyx/models/pyi_elements.py
@@ -44,6 +44,7 @@ class PyiFunction(PyiElement):
     doc: str | None = None
     signature: PyiSignature = field(default_factory=PyiSignature)
     decorators: list[str] = field(default_factory=list)
+    type_comment: str | None = None
 
 
 @dataclass

--- a/stubgen_pyx/parsing/parser.py
+++ b/stubgen_pyx/parsing/parser.py
@@ -18,8 +18,7 @@ from .file_parsing import file_parsing_preprocess
 from .preprocess import (
     preprocess,
     extract_type_comments,
-    remove_contained_newlines,
-    replace_tabs_with_spaces,
+    get_lines_with_newlines_in_brackets,
 )
 
 Errors.init_thread()
@@ -73,13 +72,19 @@ def _parse_str(source: str, module_name: str) -> ParsedSource:
     """Internal: parse preprocessed source with Cython compiler."""
     context = StringParseContext(module_name, cpp=True)
 
-    # Extract type comments from a source where bracketed multi-line
-    # expressions have been flattened. This keeps comment line numbers
-    # aligned with AST node positions, which the full `preprocess` pass
-    # would otherwise shift relative to the original source.
-    type_comments = extract_type_comments(
-        remove_contained_newlines(replace_tabs_with_spaces(source))
-    )
+    # Extract type comments from the original source, then translate
+    # original line numbers to post-preprocess line numbers by subtracting
+    # the count of in-bracket newlines that `preprocess` will collapse.
+    # We can't run that flattening up-front: comments inside a bracketed
+    # block are terminated by their newline, so removing the newline would
+    # merge the comment with following code and break tokenization.
+    type_comments_orig = extract_type_comments(source)
+    collapsed_lines = sorted(get_lines_with_newlines_in_brackets(source))
+    type_comments: dict[int, str] = {}
+    for orig_line, comment in type_comments_orig.items():
+        shift = sum(1 for line in collapsed_lines if line < orig_line)
+        type_comments[orig_line - shift] = comment
+
     source = preprocess(source)
 
     ast = parse_from_strings(module_name, source, context=context)

--- a/stubgen_pyx/parsing/parser.py
+++ b/stubgen_pyx/parsing/parser.py
@@ -6,7 +6,7 @@ See `preprocess.py` for preprocessing details.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 import typing
 
@@ -15,7 +15,12 @@ from Cython.Compiler import Errors
 from Cython.Compiler.ModuleNode import ModuleNode
 
 from .file_parsing import file_parsing_preprocess
-from .preprocess import preprocess
+from .preprocess import (
+    preprocess,
+    extract_type_comments,
+    remove_contained_newlines,
+    replace_tabs_with_spaces,
+)
 
 Errors.init_thread()
 
@@ -27,10 +32,14 @@ class ParsedSource:
     Attributes:
         source: The preprocessed source code text.
         source_ast: The Cython compiler AST.
+        type_comments: Map of line number → `# type: ...` comment captured
+            before comment stripping, keyed by 1-based line numbers that
+            align with AST node positions for typical single-line defs.
     """
 
     source: str
     source_ast: ModuleNode
+    type_comments: dict[int, str] = field(default_factory=dict)
 
 
 _DEFAULT_MODULE_NAME = "__pyx_module__"
@@ -64,13 +73,19 @@ def _parse_str(source: str, module_name: str) -> ParsedSource:
     """Internal: parse preprocessed source with Cython compiler."""
     context = StringParseContext(module_name, cpp=True)
 
+    # Extract type comments from a source where bracketed multi-line
+    # expressions have been flattened. This keeps comment line numbers
+    # aligned with AST node positions, which the full `preprocess` pass
+    # would otherwise shift relative to the original source.
+    type_comments = extract_type_comments(
+        remove_contained_newlines(replace_tabs_with_spaces(source))
+    )
     source = preprocess(source)
 
     ast = parse_from_strings(module_name, source, context=context)
     ast = typing.cast("ModuleNode", ast)
 
-    parsed = ParsedSource(source, ast)
-    return parsed
+    return ParsedSource(source, ast, type_comments=type_comments)
 
 
 def _normalize_part(part: str) -> str:

--- a/stubgen_pyx/parsing/preprocess.py
+++ b/stubgen_pyx/parsing/preprocess.py
@@ -212,6 +212,25 @@ def _get_newline_indices_in_brackets(code: str) -> list[int]:
     return results
 
 
+def get_lines_with_newlines_in_brackets(code: str) -> list[int]:
+    """1-based line numbers whose terminating newline sits inside a bracket
+    pair. These lines are joined with the following line by
+    `remove_contained_newlines`."""
+    results: list[int] = []
+    bracket_stack: list[str] = []
+
+    for token in tokenize_py(code):
+        token_str = token.string
+        if token_str in _BRACKET_PAIRS and token.type == tokenize.OP:
+            bracket_stack.append(token_str)
+        elif bracket_stack and token_str == _BRACKET_PAIRS[bracket_stack[-1]]:
+            bracket_stack.pop()
+        elif token.type == tokenize.NL and bracket_stack:
+            results.append(token.start[0])
+
+    return results
+
+
 def _get_colon_line_col_before_block(code: str) -> list[tuple[int, int]]:
     """Get (line, col) positions of colons that start code blocks (reversed)."""
     results = []

--- a/stubgen_pyx/parsing/preprocess.py
+++ b/stubgen_pyx/parsing/preprocess.py
@@ -16,6 +16,7 @@ _PreprocessTransform = Callable[[str], str]
 _TAB_PATTERN = re.compile(r"^(\t+)", flags=re.MULTILINE)
 _LINE_INDENT_PATTERN = re.compile(r"^(\s*)")
 _LINE_CONTINUATION_PATTERN = re.compile(r"\\\n\s*")
+_TYPE_COMMENT_PATTERN = re.compile(r"^#\s*type:\s")
 _BRACKET_PAIRS = {
     "(": ")",
     "[": "]",
@@ -158,6 +159,20 @@ def _get_line_indentation(line: str) -> str:
 def tokenize_py(code: str) -> Generator[tokenize.TokenInfo, None, None]:
     """Tokenize Python/Cython code."""
     return tokenize.generate_tokens(io.StringIO(code).readline)
+
+
+def extract_type_comments(code: str) -> dict[int, str]:
+    """Map line number → `# type: ...` comment text.
+
+    Matches any PEP 484 style type comment (e.g. `# type: ignore[...]`,
+    `# type: int`, `# type: () -> int`). Run before `remove_comments` so
+    the comments are still present.
+    """
+    results: dict[int, str] = {}
+    for token in tokenize_py(code):
+        if token.type == tokenize.COMMENT and _TYPE_COMMENT_PATTERN.match(token.string):
+            results[token.start[0]] = token.string
+    return results
 
 
 def _get_comment_span_indices(code: str) -> list[tuple[int, int]]:

--- a/stubgen_pyx/postprocessing/pipeline.py
+++ b/stubgen_pyx/postprocessing/pipeline.py
@@ -33,7 +33,7 @@ def postprocessing_pipeline(
     Returns:
         Processed .pyi code after all enabled transformations.
     """
-    pyi_ast = ast.parse(pyi_code)
+    pyi_ast = ast.parse(pyi_code, type_comments=True)
 
     if (
         not config.no_deduplicate_imports

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -103,6 +103,7 @@ class StubgenPyx:
         parse_result = parse_pyx(pyx_str, module_name=module_name, pyx_path=pyx_path)
 
         module_visitor = ModuleVisitor(node=parse_result.source_ast)
+        self.converter.type_comments = parse_result.type_comments
         module = self.converter.convert_module(module_visitor, parse_result.source)
 
         if pxd_str and not self.config.no_pxd_to_stubs:
@@ -110,6 +111,7 @@ class StubgenPyx:
                 pxd_str, module_name=module_name, pyx_path=pyx_path
             )
             pxd_visitor = ModuleVisitor(node=pxd_parse_result.source_ast)
+            self.converter.type_comments = pxd_parse_result.type_comments
             pxd_module = self.converter.convert_module(
                 pxd_visitor, pxd_parse_result.source
             )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -373,6 +373,80 @@ def test_convert_single_file_dry_run(temp_dir):
     assert not pyx_file.with_suffix(".pyi").exists()
 
 
+def test_type_comment_propagates(temp_dir):
+    """`# type: ...` comments on def lines must propagate into the .pyi."""
+    pyx_file = temp_dir / "test.pyx"
+    pyx_file.write_text(
+        """
+class Foo:
+    def __isub__(self): # type: ignore[]
+        return self
+
+    def __iadd__(self, other):  # type: ignore[misc, override]
+        return self
+
+def bar(): # type: ignore[no-untyped-def]
+    pass
+
+def baz(x): # type: (int) -> int
+    return x
+
+def quux():
+    pass
+"""
+    )
+
+    stubgen = StubgenPyx()
+    result = stubgen.convert_str(pyx_file.read_text(), pyx_path=pyx_file)
+
+    isub_line = next(
+        line for line in result.splitlines() if "def __isub__" in line
+    )
+    assert "# type: ignore[]" in isub_line
+
+    iadd_line = next(
+        line for line in result.splitlines() if "def __iadd__" in line
+    )
+    assert "# type: ignore[misc, override]" in iadd_line
+
+    bar_line = next(line for line in result.splitlines() if "def bar" in line)
+    assert "# type: ignore[no-untyped-def]" in bar_line
+
+    baz_line = next(line for line in result.splitlines() if "def baz" in line)
+    assert "# type: (int) -> int" in baz_line
+
+    quux_line = next(line for line in result.splitlines() if "def quux" in line)
+    assert "type:" not in quux_line
+
+
+def test_type_comment_propagates_after_bracketed_import(temp_dir):
+    """A multi-line bracketed import shifts AST line numbers relative to the
+    original source. The `# type:` comment lookup must use post-flattening
+    line numbers so the comment still attaches to the right def."""
+    pyx_file = temp_dir / "test.pyx"
+    pyx_file.write_text(
+        """
+from collections.abc import (
+    MutableSet,
+    Set as AbstractSet,
+)
+from typing import Any
+
+
+def shifted(it: AbstractSet[Any]) -> Any:  # type: ignore[override,misc]
+    return it
+"""
+    )
+
+    stubgen = StubgenPyx()
+    result = stubgen.convert_str(pyx_file.read_text(), pyx_path=pyx_file)
+
+    shifted_line = next(
+        line for line in result.splitlines() if "def shifted" in line
+    )
+    assert "# type: ignore[override,misc]" in shifted_line
+
+
 def test_convert_single_file_in_output_dir_dry_run(temp_dir, temp_outdir):
     """Test glob conversion with a single files in output dir with dry run."""
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -447,6 +447,35 @@ def shifted(it: AbstractSet[Any]) -> Any:  # type: ignore[override,misc]
     assert "# type: ignore[override,misc]" in shifted_line
 
 
+def test_conversion_succeeds_with_comments_inside_brackets(temp_dir):
+    """A `#` comment inside a bracketed expression is terminated by its
+    newline. Stub generation must not collapse that newline away, or the
+    comment swallows the following dict entries and tokenization fails."""
+    pyx_file = temp_dir / "test.pyx"
+    pyx_file.write_text(
+        """
+def make_map():
+    return {
+        1: 'one',     # leading
+        2: 'two',     # the comment ends here, dict continues
+        3: 'three',
+    }
+
+
+def tagged(): # type: ignore[no-untyped-def]
+    pass
+"""
+    )
+
+    stubgen = StubgenPyx()
+    result = stubgen.convert_str(pyx_file.read_text(), pyx_path=pyx_file)
+
+    tagged_line = next(
+        line for line in result.splitlines() if "def tagged" in line
+    )
+    assert "# type: ignore[no-untyped-def]" in tagged_line
+
+
 def test_convert_single_file_in_output_dir_dry_run(temp_dir, temp_outdir):
     """Test glob conversion with a single files in output dir with dry run."""
 


### PR DESCRIPTION
For `cuda-core`, we are running into a [`mypy` "bug"](https://github.com/python/mypy/issues/11941) when annotating `__ior__` and `__isub__`.  It's pretty hairy, maybe unlikely to be resolved any time soon, and even `typeshed` is currently just adding a `# type: ignore[...]` annotation to get around it.

In any event, these sorts of "escape hatches" to work around type checker shortcomings seems like it will be generally useful.  This PR just passes these type annotations in the .pyx along to the .pyi file.