### PR TITLE
Merge declarations between pyx and pxd classes instead of favoring pyx

### DIFF
--- a/stubgen_pyx/models/pyi_elements.py
+++ b/stubgen_pyx/models/pyi_elements.py
@@ -76,6 +76,27 @@ class PyiScope(PyiElement):
     classes: list[PyiClass] = field(default_factory=list)
     enums: list[PyiEnum | PyiAssignment] = field(default_factory=list)
 
+    def deduplicate_assignments(self) -> None:
+        """Remove duplicate assignments from the scope while preserving order."""
+        seen: set[str] = set()
+        unique_assignments: list[PyiAssignment] = []
+        for assignment in self.assignments:
+            name = assignment.statement.partition("=")[0].partition(":")[0].strip()
+            if not name or name not in seen:
+                if name:
+                    seen.add(name)
+                unique_assignments.append(assignment)
+        self.assignments = unique_assignments
+
+    def merge_classes(self, extra_classes: list[PyiClass]) -> None:
+        """Merge classes with the same name and preserve unique declarations."""
+        existing_classes: dict[str, PyiClass] = {cls.name: cls for cls in self.classes}
+        for extra_class in extra_classes:
+            if extra_class.name in existing_classes:
+                existing_classes[extra_class.name].merge_with(extra_class)
+            else:
+                self.classes.append(extra_class)
+
 
 @dataclass
 class PyiClass(PyiElement):
@@ -87,6 +108,24 @@ class PyiClass(PyiElement):
     metaclass: str | None = None
     decorators: list[str] = field(default_factory=list)
     scope: PyiScope = field(default_factory=PyiScope)
+
+    def merge_with(self, other: PyiClass) -> None:
+        """Merge another class declaration into this class."""
+        if self.doc is None:
+            self.doc = other.doc
+
+        self.bases = [*dict.fromkeys(self.bases + other.bases)]
+        if self.metaclass is None:
+            self.metaclass = other.metaclass
+
+        self.decorators = [*dict.fromkeys(self.decorators + other.decorators)]
+
+        self.scope.assignments += other.scope.assignments
+        self.scope.deduplicate_assignments()
+
+        self.scope.functions += other.scope.functions
+        self.scope.merge_classes(other.scope.classes)
+        self.scope.enums += other.scope.enums
 
 
 @dataclass

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -128,17 +128,9 @@ class StubgenPyx:
 
         module.scope.enums += extra_enums
         module.scope.assignments += extra_assignments
+        module.scope.deduplicate_assignments()
+        module.scope.merge_classes(extra_classes)
         module.imports += extra_imports
-
-        module_class_names = {
-            class_element.name for class_element in module.scope.classes
-        }
-
-        module.scope.classes += [
-            extra_class
-            for extra_class in extra_classes
-            if extra_class.name not in module_class_names
-        ]
 
         module.imports.append(
             PyiImport(

--- a/tests/fixtures/test_merged.pxd
+++ b/tests/fixtures/test_merged.pxd
@@ -1,0 +1,3 @@
+cdef class MergedClass:
+    cdef public int merged_value
+    cpdef int function(self)

--- a/tests/fixtures/test_merged.pyx
+++ b/tests/fixtures/test_merged.pyx
@@ -1,0 +1,13 @@
+cdef class MergedClass:
+    original_value: int = 0
+    python_attribute: int = 1
+
+    def __init__(self, int v):
+        self.original_value = v
+        self.merged_value = v
+
+    cpdef int function(self):
+        return self.merged_value
+
+    def set_merged_value(self, int v):
+        self.merged_value = v

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -126,6 +126,63 @@ def test_convert_glob_with_pxd_file(temp_dir):
     assert results[0].success is True
 
 
+def test_compile_str_to_module_deduplicates_pxd_assignments(temp_dir):
+    """Test that assignments from .pxd and .pyx are merged without duplicates."""
+    pyx_file = temp_dir / "test.pyx"
+    pyx_file.write_text("x = 1\n")
+
+    pxd_content = "x: int = 1\n"
+    stubgen = StubgenPyx()
+
+    module = stubgen.compile_str_to_module(
+        pyx_file.read_text(),
+        pxd_str=pxd_content,
+        pyx_path=pyx_file,
+    )
+
+    assert len(module.scope.assignments) == 1
+    assert module.scope.assignments[0].statement.startswith("x")
+
+
+def test_compile_str_to_module_merges_pxd_class_declarations(temp_dir):
+    """Test that pxd class declarations are merged into existing pyx classes."""
+    pyx_file = temp_dir / "test.pyx"
+    pyx_file.write_text(
+        """
+class Config:
+    python_attribute: int = 1
+
+    def pyx_method(self):
+        pass
+"""
+    )
+
+    pxd_content = """
+cdef class Config:
+    cdef public int pxd_value
+"""
+    stubgen = StubgenPyx()
+
+    module = stubgen.compile_str_to_module(
+        pyx_file.read_text(),
+        pxd_str=pxd_content,
+        pyx_path=pyx_file,
+    )
+
+    config_cls = next(cls for cls in module.scope.classes if cls.name == "Config")
+    assert len(module.scope.classes) == 1
+
+    assert any(func.name == "pyx_method" for func in config_cls.scope.functions)
+    assert any(
+        assign.statement.startswith("pxd_value")
+        for assign in config_cls.scope.assignments
+    )
+    assert any(
+        assign.statement.startswith("python_attribute")
+        for assign in config_cls.scope.assignments
+    )
+
+
 def test_convert_glob_with_standalone_pxd_file(temp_dir):
     """Test glob conversion of a standalone .pxd file when no .pyx exists."""
     pxd_file = temp_dir / "test.pxd"


### PR DESCRIPTION
Fixes #23 

This produces the following behavior:

```cython
# test_merged.pyx

cdef class MergedClass:
    original_value: int = 0
    python_attribute: int = 1

    def __init__(self, int v):
        self.original_value = v
        self.merged_value = v

    cpdef int function(self):
        return self.merged_value

    def set_merged_value(self, int v):
        self.merged_value = v
```
and
```cython
# test_merged.pxd

cdef class MergedClass:
    cdef public int merged_value
    cpdef int function(self)
```
produces
```cython
# test_merged.pyi

class MergedClass:
    original_value: int = 0
    python_attribute: int = 1
    merged_value: int

    def function(self) -> int:
        ...

    def __init__(self, v: int):
        ...

    def set_merged_value(self, v: int):
        ...
```
