### PR TITLE
Remove __future__.annotations import for pyi files

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,6 @@ def matrix_product(Matrix a, Matrix b) -> Matrix:
 
 """Mathematical utilities for scientific computing."""
 
-from __future__ import annotations
-
 class Matrix:
     """A simple matrix class."""
 

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -14,7 +14,7 @@ from .conversion.converter import Converter
 from .builders.builder import Builder
 from .parsing.parser import parse_pyx, path_to_module_name
 from .postprocessing.pipeline import postprocessing_pipeline
-from .models.pyi_elements import PyiImport, PyiModule
+from .models.pyi_elements import PyiModule
 
 
 logger = logging.getLogger(__name__)
@@ -131,12 +131,6 @@ class StubgenPyx:
         module.scope.deduplicate_assignments()
         module.scope.merge_classes(extra_classes)
         module.imports += extra_imports
-
-        module.imports.append(
-            PyiImport(
-                statement="from __future__ import annotations",
-            )
-        )
 
         return module
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,7 +38,6 @@ def test_convert_empty_pyx_file(temp_dir):
     result = stubgen.convert_str(pyx_file.read_text(), pyx_path=pyx_file)
 
     assert isinstance(result, str)
-    assert "from __future__ import annotations" in result
     assert "stubgen-pyx" in result  # Stubgen attribution
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,8 +15,6 @@ from stubgen_pyx.config import StubgenPyxConfig
 def test_pipeline_with_all_disabled():
     """Test pipeline when all postprocessing is disabled."""
     pyi_code = """
-from __future__ import annotations
-
 import os
 import sys
 
@@ -34,7 +32,6 @@ def hello() -> None:
     result = postprocessing_pipeline(pyi_code, config)
 
     # Should still include attribution
-    assert "from __future__ import annotations" in result
     assert "stubgen-pyx" in result
 
 


### PR DESCRIPTION
Fixes #21 

This removes `from __future__ import annotations` from pyi files as per [https://typing.python.org/en/latest/guides/writing_stubs.html#language-features](https://typing.python.org/en/latest/guides/writing_stubs.html#language-features)