### PR TITLE
Remove equals_star preprocess and parse pxd files with Cython flag

### DIFF
--- a/stubgen_pyx/parsing/file_parsing.py
+++ b/stubgen_pyx/parsing/file_parsing.py
@@ -42,7 +42,7 @@ def file_parsing_preprocess(source: Path, code: str) -> str:
             raise MaxIncludeDepthError(
                 f"Too many includes in source file (>{_STUBGEN_MAX_INCLUDE_DEPTH}). Possible circular include? Increase `STUBGEN_MAX_INCLUDE_DEPTH` environment variable."
             )
-    return _replace_equals_star(expanded)
+    return expanded
 
 
 def _read_file_fallback(path: Path, fallback: str) -> str:
@@ -112,25 +112,3 @@ def _get_includes(source: Path, code: str) -> list[_Include]:
 
     results.reverse()
     return results
-
-
-def _get_equals_star_indices(code: str) -> list[tuple[int, int]]:
-    results = []
-    last_token: tokenize.TokenInfo | None = None
-
-    line_converter = LineColConverter(code)
-    for token in tokenize_py(code):
-        if token.string == "*" and last_token and last_token.string == "=":
-            start = line_converter.line_col_to_offset(token.start)
-            end = line_converter.line_col_to_offset(token.end)
-            results.append((start, end))
-        last_token = token
-
-    results.reverse()
-    return results
-
-
-def _replace_equals_star(code: str) -> str:
-    for start, end in _get_equals_star_indices(code):
-        code = remove_indices(code, start, end, replace_with="...")
-    return code

--- a/stubgen_pyx/parsing/parser.py
+++ b/stubgen_pyx/parsing/parser.py
@@ -7,12 +7,13 @@ See `preprocess.py` for preprocessing details.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from io import StringIO
 from pathlib import Path
-import typing
 
-from Cython.Compiler.TreeFragment import parse_from_strings, StringParseContext
-from Cython.Compiler import Errors
+from Cython.Compiler.TreeFragment import StringParseContext
+from Cython.Compiler import Errors, Parsing
 from Cython.Compiler.ModuleNode import ModuleNode
+from Cython.Compiler.Scanning import PyrexScanner, StringSourceDescriptor
 
 from .file_parsing import file_parsing_preprocess
 from .preprocess import (
@@ -45,7 +46,10 @@ _DEFAULT_MODULE_NAME = "__pyx_module__"
 
 
 def parse_pyx(
-    source: str, module_name: str | None = None, pyx_path: Path | None = None
+    source: str,
+    module_name: str | None = None,
+    pyx_path: Path | None = None,
+    pxd: bool = False,
 ) -> ParsedSource:
     """Parse Cython source code.
 
@@ -55,6 +59,7 @@ def parse_pyx(
         source: Cython source code string.
         module_name: Optional module name for error messages.
         pyx_path: Optional file path for context and preprocessing.
+        pxd: Whether the source is a .pxd file. If pyx_path is also provided and it's a .pxd, this is overridden.
 
     Returns:
         ParsedSource with preprocessed code and AST.
@@ -62,15 +67,24 @@ def parse_pyx(
     module_name = module_name or _DEFAULT_MODULE_NAME
 
     if pyx_path:
+        pxd = pxd or pyx_path.suffix == ".pxd"
         source = file_parsing_preprocess(pyx_path, source)
         module_name = path_to_module_name(pyx_path)
 
-    return _parse_str(source, module_name)
+    return _parse_str(source, module_name, pxd)
 
 
-def _parse_str(source: str, module_name: str) -> ParsedSource:
-    """Internal: parse preprocessed source with Cython compiler."""
-    context = StringParseContext(module_name, cpp=True)
+def _parse_str(source: str, module_name: str, pxd: bool = False) -> ParsedSource:
+    """Simplified version of Cython.Compiler.TreeFragment.parse_from_strings but with allowing pxd.
+
+    Args:
+        source: Cython source code string.
+        module_name: Module name for error messages.
+        pxd: Whether the source is a .pxd file.
+
+    Returns:
+        ParsedSource with preprocessed code and AST.
+    """
 
     # Extract type comments from the original source, then translate
     # original line numbers to post-preprocess line numbers by subtracting
@@ -87,10 +101,27 @@ def _parse_str(source: str, module_name: str) -> ParsedSource:
 
     source = preprocess(source)
 
-    ast = parse_from_strings(module_name, source, context=context)
-    ast = typing.cast("ModuleNode", ast)
+    encoding = "UTF-8"
+    initial_pos = (module_name, 1, 0)
 
-    return ParsedSource(source, ast, type_comments=type_comments)
+    context = StringParseContext(module_name)
+    code_source = StringSourceDescriptor(module_name, source)
+    buf = StringIO(source)
+
+    scope = context.find_module(module_name, pos=initial_pos, need_pxd=False)
+    scanner = PyrexScanner(
+        buf,
+        filename=code_source,
+        source_encoding=encoding,
+        scope=scope,
+        context=context,
+        initial_pos=initial_pos,
+    )
+    ctx = Parsing.Ctx(allow_struct_enum_decorator=True)
+
+    tree = Parsing.p_module(scanner, pxd, module_name, ctx=ctx)
+
+    return ParsedSource(source, tree, type_comments)
 
 
 def _normalize_part(part: str) -> str:

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -116,7 +116,7 @@ class StubgenPyx:
 
         if pxd_str and self.config.pxd_to_stubs:
             pxd_parse_result = parse_pyx(
-                pxd_str, module_name=module_name, pyx_path=pyx_path
+                pxd_str, module_name=module_name, pyx_path=pyx_path, pxd=True
             )
             pxd_visitor = ModuleVisitor(node=pxd_parse_result.source_ast)
             pxd_module = converter.convert_module(

--- a/tests/fixtures/test_merged.pxd
+++ b/tests/fixtures/test_merged.pxd
@@ -1,3 +1,3 @@
 cdef class MergedClass:
     cdef public int merged_value
-    cpdef int function(self)
+    cpdef int function(self, int x = *)

--- a/tests/fixtures/test_merged.pyx
+++ b/tests/fixtures/test_merged.pyx
@@ -6,7 +6,7 @@ cdef class MergedClass:
         self.original_value = v
         self.merged_value = v
 
-    cpdef int function(self):
+    cpdef int function(self, int x = 100):
         return self.merged_value
 
     def set_merged_value(self, int v):

--- a/tests/test_file_parsing.py
+++ b/tests/test_file_parsing.py
@@ -53,43 +53,8 @@ class TestTryParseString:
         assert result == ""
 
 
-class TestGetIncludesAndEqualsstar:
+class TestGetIncludes:
     """Test include and equals-star replacement functions."""
-
-    def test_replace_equals_star_no_matches(self):
-        """Test that code without = * is unchanged."""
-        code = """
-x = 5
-y = z * 2
-"""
-        result = file_parsing._replace_equals_star(code)
-        assert "x = 5" in result
-        assert "y = z * 2" in result
-
-    def test_replace_equals_star_single_match(self):
-        """Test replacing a single = * occurrence."""
-        code = "x = *\n"
-        result = file_parsing._replace_equals_star(code)
-        assert "..." in result
-        assert "*" not in result or "z * 2" in code
-
-    def test_replace_equals_star_multiple_matches(self):
-        """Test replacing multiple = * occurrences."""
-        code = "x = *\ny = *\nz = 5"
-        result = file_parsing._replace_equals_star(code)
-        assert result.count("...") >= 2
-
-    def test_get_equals_star_indices_empty(self):
-        """Test getting indices when there are no matches."""
-        code = "x = 5\ny = z * 2"
-        indices = file_parsing._get_equals_star_indices(code)
-        assert len(indices) == 0
-
-    def test_get_equals_star_indices_single(self):
-        """Test getting indices for a single match."""
-        code = "x = *"
-        indices = file_parsing._get_equals_star_indices(code)
-        assert len(indices) >= 0  # May or may not find it depending on tokenization
 
     def test_expand_includes_no_includes(self):
         """Test that code without includes is unchanged."""
@@ -159,19 +124,6 @@ def hello():
 """
             result = file_parsing.file_parsing_preprocess(source_file, code)
             assert "def hello" in result
-
-    def test_file_parsing_preprocess_with_equals_star(self):
-        """Test preprocessing code with = * pattern."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            source_file = Path(tmpdir) / "source.pyx"
-            source_file.write_text("")
-
-            code = """
-x = *
-y = 5
-"""
-            result = file_parsing.file_parsing_preprocess(source_file, code)
-            assert "..." in result
 
     def test_file_parsing_preprocess_combined(self):
         """Test preprocessing with both includes and *= patterns."""


### PR DESCRIPTION
This replaces the `Cython.Compiler.TreeFragment.parse_from_strings` call in `parsing.parser._parse_str` with a custom parsing procedure that appropriately handles pxd files and their syntax (namely, `=*` statements in class and function declarations).

Addresses the parsing error in #27    