### PR TITLE
Add fused type signature support

### DIFF
--- a/stubgen_pyx/analysis/visitor.py
+++ b/stubgen_pyx/analysis/visitor.py
@@ -19,6 +19,7 @@ class ScopeVisitor(TreeVisitor):
         cdef_functions: Collected Cython (cdef) function definitions.
         classes: Collected class definitions.
         enums: Collected enum definitions.
+        fused_types: Collected Cython fused type definitions.
     """
 
     node: Nodes.Node
@@ -30,6 +31,7 @@ class ScopeVisitor(TreeVisitor):
     cdef_functions: list[Nodes.CFuncDefNode] = field(default_factory=list, init=False)
     classes: list[ClassVisitor] = field(default_factory=list, init=False)
     enums: list[Nodes.CEnumDefNode] = field(default_factory=list, init=False)
+    fused_types: list[Nodes.FusedTypeNode] = field(default_factory=list, init=False)
     cdef_variables: list[Nodes.CVarDefNode] = field(default_factory=list, init=False)
     cdef_structs_or_unions: list[Nodes.CStructOrUnionDefNode] = field(
         default_factory=list, init=False
@@ -112,6 +114,11 @@ class ScopeVisitor(TreeVisitor):
         """Collect simple Cython type definitions."""
         if isinstance(node.declarator, Nodes.CNameDeclaratorNode):
             self.assignments.append(node)
+        return node
+
+    def visit_FusedTypeNode(self, node):
+        """Collect Cython fused type definitions."""
+        self.fused_types.append(node)
         return node
 
     def visit_CVarDefNode(self, node: Nodes.CVarDefNode):
@@ -240,7 +247,7 @@ def _collect_attribute(node) -> str:
         attribute = attribute.obj
 
     if isinstance(attribute, ExprNodes.NameNode):
-        names.append(attribute.name)  # type: ignore
+        names.append(attribute.name)
 
     names.reverse()
 

--- a/stubgen_pyx/analysis/visitor.py
+++ b/stubgen_pyx/analysis/visitor.py
@@ -19,6 +19,7 @@ class ScopeVisitor(TreeVisitor):
         cdef_functions: Collected Cython (cdef) function definitions.
         classes: Collected class definitions.
         enums: Collected enum definitions.
+        fused_types: Collected Cython fused type definitions.
     """
 
     node: Nodes.Node
@@ -30,6 +31,7 @@ class ScopeVisitor(TreeVisitor):
     cdef_functions: list[Nodes.CFuncDefNode] = field(default_factory=list, init=False)
     classes: list[ClassVisitor] = field(default_factory=list, init=False)
     enums: list[Nodes.CEnumDefNode] = field(default_factory=list, init=False)
+    fused_types: list[Nodes.FusedTypeNode] = field(default_factory=list, init=False)
     cdef_variables: list[Nodes.CVarDefNode] = field(default_factory=list, init=False)
 
     def __post_init__(self):
@@ -105,6 +107,11 @@ class ScopeVisitor(TreeVisitor):
         """Collect simple Cython type definitions."""
         if isinstance(node.declarator, Nodes.CNameDeclaratorNode):
             self.assignments.append(node)
+        return node
+
+    def visit_FusedTypeNode(self, node):
+        """Collect Cython fused type definitions."""
+        self.fused_types.append(node)
         return node
 
     def visit_CVarDefNode(self, node: Nodes.CVarDefNode):
@@ -227,7 +234,7 @@ def _collect_attribute(node) -> str:
         attribute = attribute.obj
 
     if isinstance(attribute, ExprNodes.NameNode):
-        names.append(attribute.name)  # type: ignore
+        names.append(attribute.name)
 
     names.reverse()
 

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -425,7 +425,7 @@ def _restore_fused_memoryview_annotations(
         arg_nodes = getattr(getattr(node, "declarator", None), "args", [])
     else:
         arg_nodes = getattr(node, "args", [])
-    for arg, arg_node in zip(signature.args, arg_nodes, strict=False):
+    for arg, arg_node in zip(signature.args, arg_nodes):
         fused_name = _fused_memoryview_name(arg_node, fused_types)
         if arg.annotation == "memoryview" and fused_name is not None:
             arg.annotation = fused_name

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -71,6 +71,7 @@ class Converter:
         source_code: str,
         type_comments: dict[int, str] | None = None,
         include_docstrings: bool = True,
+        inherited_fused_types: dict[str, PyiFusedType] | None = None,
     ) -> PyiModule:
         """Convert a ModuleVisitor to a PyiModule.
 
@@ -84,7 +85,14 @@ class Converter:
         """
         tc = type_comments or {}
         doc = docstring_to_string(visitor.node.doc) if visitor.node.doc else None
-        scope = self.convert_scope(visitor.scope, source_code, tc, include_docstrings)
+        scope = self.convert_scope(
+            visitor.scope,
+            source_code,
+            tc,
+            include_docstrings,
+            inherited_fused_types,
+            emit_inherited_fused_typevars=True,
+        )
         typing_import = "from typing import Any, Any as _Any, TypeAlias as _TypeAlias, TypedDict"
         if _scope_uses_typevar(scope):
             typing_import += ", TypeVar"
@@ -135,6 +143,7 @@ class Converter:
         type_comments: dict[int, str] | None = None,
         include_docstrings: bool = True,
         inherited_fused_types: dict[str, PyiFusedType] | None = None,
+        emit_inherited_fused_typevars: bool = False,
     ) -> PyiScope:
         """Convert a ScopeVisitor to a PyiScope.
 
@@ -193,8 +202,11 @@ class Converter:
             )
             for class_visitor in visitor.classes
         ]
+        typevar_candidates = (
+            fused_types if emit_inherited_fused_typevars else local_fused_types
+        )
         fused_typevar_names = _find_typevar_fused_types(
-            PyiScope(functions=functions, classes=classes), local_fused_types
+            PyiScope(functions=functions, classes=classes), typevar_candidates
         )
 
         return PyiScope(

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -142,6 +142,8 @@ class Converter:
         line position, rather than emitting all cdef functions first.
         """
         tc = type_comments or {}
+        local_fused_types = self.convert_fused_types(visitor.fused_types)
+        fused_types = local_fused_types
 
         cdef_assignments: list[PyiAssignment] = []
         for cdef_variable in visitor.cdef_variables:
@@ -153,7 +155,9 @@ class Converter:
         cdef_funcs = [
             (
                 node.pos[1],
-                self.convert_cdef_func(node, source_code, tc, include_docstrings),
+                self.convert_cdef_func(
+                    node, source_code, tc, include_docstrings, fused_types
+                ),
             )
             for node in visitor.cdef_functions
         ]
@@ -232,6 +236,7 @@ class Converter:
         source_code: str,
         type_comments: dict[int, str] | None = None,
         include_docstrings: bool = True,
+        fused_types: dict[str, PyiFusedType] | None = None,
     ) -> PyiFunction:
         """Convert a C function definition node to PyiFunction."""
         tc = type_comments or {}
@@ -242,7 +247,7 @@ class Converter:
             is_async=False,
             doc=doc if include_docstrings else None,
             decorators=get_decorators(source_code, cdef_func),
-            signature=get_signature(cdef_func),
+            signature=_resolve_fused_signature(get_signature(cdef_func), fused_types or {}),
             type_comment=self._type_comment_for(cdef_func, tc),
         )
 
@@ -331,6 +336,70 @@ class Converter:
             return PyiEnum(enum_name=name, names=get_enum_names(node))
         # Make it usable as an alias for int
         return PyiAssignment(f"{node.name}: _TypeAlias = int")  # type: ignore
+
+
+def _resolve_fused_signature(
+    signature: PyiSignature, fused_types: dict[str, PyiFusedType]
+) -> PyiSignature:
+    usage = _signature_fused_usage(signature, fused_types)
+    for arg in signature.args:
+        if arg.annotation is not None:
+            arg.annotation = _resolved_fused_annotation(
+                arg.annotation, usage, fused_types
+            )
+    if signature.return_type is not None:
+        signature.return_type = _resolved_fused_annotation(
+            signature.return_type, usage, fused_types
+        )
+    return signature
+
+
+def _resolved_fused_annotation(
+    annotation: str,
+    usage: dict[str, tuple[int, bool]],
+    fused_types: dict[str, PyiFusedType],
+) -> str:
+    resolved = annotation
+    for name in fused_types:
+        if not _annotation_uses_name(resolved, name):
+            continue
+        param_count, used_as_return = usage[name]
+        replacement = name
+        if (not used_as_return and param_count <= 1) or param_count == 0:
+            replacement = " | ".join(fused_types[name].concrete_types)
+        resolved = _replace_annotation_name(resolved, name, replacement)
+    return resolved
+
+
+def _signature_fused_usage(
+    signature: PyiSignature, fused_types: dict[str, PyiFusedType]
+) -> dict[str, tuple[int, bool]]:
+    usage: dict[str, tuple[int, bool]] = {}
+    for name in fused_types:
+        param_count = sum(
+            _annotation_uses_name(arg.annotation, name) for arg in signature.args
+        )
+        used_as_return = _annotation_uses_name(signature.return_type, name)
+        if param_count or used_as_return:
+            usage[name] = (param_count, used_as_return)
+    return usage
+
+
+def _annotation_uses_name(annotation: str | None, name: str) -> bool:
+    if annotation is None:
+        return False
+    return name in _annotation_parts(annotation)
+
+
+def _replace_annotation_name(annotation: str, name: str, replacement: str) -> str:
+    parts = [
+        replacement if part == name else part for part in _annotation_parts(annotation)
+    ]
+    return " | ".join(parts)
+
+
+def _annotation_parts(annotation: str) -> list[str]:
+    return [part.strip() for part in annotation.split("|")]
 
 
 def _type_name(node: Nodes.Node) -> str | None:

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -96,7 +96,7 @@ class Converter:
         typing_import = (
             "from typing import Any, Any as _Any, TypeAlias as _TypeAlias, TypedDict"
         )
-        if _scope_uses_typevar(scope):
+        if any("TypeVar(" in assignment.statement for assignment in scope.assignments):
             typing_import += ", TypeVar"
         return PyiModule(
             doc=doc if include_docstrings else None,
@@ -207,9 +207,19 @@ class Converter:
         typevar_candidates = (
             fused_types if emit_inherited_fused_typevars else local_fused_types
         )
-        fused_typevar_names = _find_typevar_fused_types(
-            PyiScope(functions=functions, classes=classes), typevar_candidates
-        )
+        typevar_scan_scope = PyiScope(functions=functions, classes=classes)
+        fused_typevar_names = [
+            name
+            for name in typevar_candidates
+            if any(
+                any(
+                    _annotation_uses_name(arg.annotation, name)
+                    for arg in function.signature.args
+                )
+                or _annotation_uses_name(function.signature.return_type, name)
+                for function in _scope_functions(typevar_scan_scope)
+            )
+        ]
 
         return PyiScope(
             assignments=[
@@ -294,7 +304,7 @@ class Converter:
             type_nodes = getattr(node, "types")
             concrete_types = tuple(
                 dict.fromkeys(
-                    _normalize_type_name(type_name)
+                    _C_TO_PYTHON.get(type_name, type_name)
                     for type_name in (_type_name(type_node) for type_node in type_nodes)
                     if type_name is not None
                 )
@@ -422,7 +432,14 @@ def _resolve_fused_signature(
     signature: PyiSignature, fused_types: dict[str, PyiFusedType]
 ) -> PyiSignature:
     """Rewrite a signature's fused-type annotations to their resolved Python form."""
-    usage = _signature_fused_usage(signature, fused_types)
+    usage: dict[str, tuple[int, bool]] = {}
+    for name in fused_types:
+        param_count = sum(
+            _annotation_uses_name(arg.annotation, name) for arg in signature.args
+        )
+        used_as_return = _annotation_uses_name(signature.return_type, name)
+        if param_count or used_as_return:
+            usage[name] = (param_count, used_as_return)
     for arg in signature.args:
         if arg.annotation is not None:
             arg.annotation = _resolved_fused_annotation(
@@ -451,43 +468,11 @@ def _resolved_fused_annotation(
             replacement = "object"
         elif (not used_as_return and param_count <= 1) or param_count == 0:
             replacement = " | ".join(fused_types[name].concrete_types)
-        resolved = _replace_annotation_name(resolved, name, replacement)
-    return resolved
-
-
-def _signature_fused_usage(
-    signature: PyiSignature, fused_types: dict[str, PyiFusedType]
-) -> dict[str, tuple[int, bool]]:
-    """Count param/return occurrences of each fused type name in a signature."""
-    usage: dict[str, tuple[int, bool]] = {}
-    for name in fused_types:
-        param_count = sum(
-            _annotation_uses_name(arg.annotation, name) for arg in signature.args
+        resolved = " | ".join(
+            replacement if part == name else part
+            for part in _annotation_parts(resolved)
         )
-        used_as_return = _annotation_uses_name(signature.return_type, name)
-        if param_count or used_as_return:
-            usage[name] = (param_count, used_as_return)
-    return usage
-
-
-def _find_typevar_fused_types(
-    scope: PyiScope, fused_types: dict[str, PyiFusedType]
-) -> list[str]:
-    """Return fused type names actually referenced by any function signature in the scope."""
-    used: list[str] = []
-    for name in fused_types:
-        for function in _scope_functions(scope):
-            if _signature_uses_name(function.signature, name):
-                used.append(name)
-                break
-    return used
-
-
-def _signature_uses_name(signature: PyiSignature, name: str) -> bool:
-    """Return True if the given name appears in any argument or return annotation."""
-    return any(
-        _annotation_uses_name(arg.annotation, name) for arg in signature.args
-    ) or _annotation_uses_name(signature.return_type, name)
+    return resolved
 
 
 def _scope_functions(scope: PyiScope) -> list[PyiFunction]:
@@ -498,24 +483,11 @@ def _scope_functions(scope: PyiScope) -> list[PyiFunction]:
     return functions
 
 
-def _scope_uses_typevar(scope: PyiScope) -> bool:
-    """Return True if the scope contains any TypeVar assignment."""
-    return any("TypeVar(" in assignment.statement for assignment in scope.assignments)
-
-
 def _annotation_uses_name(annotation: str | None, name: str) -> bool:
     """Return True if the given name appears as a part of the (union) annotation."""
     if annotation is None:
         return False
     return name in _annotation_parts(annotation)
-
-
-def _replace_annotation_name(annotation: str, name: str, replacement: str) -> str:
-    """Return the annotation with every occurrence of name replaced by replacement."""
-    parts = [
-        replacement if part == name else part for part in _annotation_parts(annotation)
-    ]
-    return " | ".join(parts)
 
 
 def _annotation_parts(annotation: str) -> list[str]:
@@ -532,8 +504,3 @@ def _type_name(node: Nodes.Node) -> str | None:
     if isinstance(node, Nodes.TemplatedTypeNode):
         return _type_name(getattr(node, "base_type_node"))
     return None
-
-
-def _normalize_type_name(type_name: str) -> str:
-    """Map a raw C type name to its Python equivalent, leaving unknown names unchanged."""
-    return _C_TO_PYTHON.get(type_name, type_name)

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -258,7 +258,12 @@ class Converter:
             is_async=False,
             doc=doc if include_docstrings else None,
             decorators=get_decorators(source_code, cdef_func),
-            signature=_resolve_fused_signature(get_signature(cdef_func), fused_types or {}),
+            signature=_resolve_fused_signature(
+                _restore_fused_memoryview_annotations(
+                    get_signature(cdef_func), cdef_func, fused_types or {}
+                ),
+                fused_types or {},
+            ),
             type_comment=self._type_comment_for(cdef_func, tc),
         )
 
@@ -270,9 +275,11 @@ class Converter:
             name = getattr(node, "name")
             type_nodes = getattr(node, "types")
             concrete_types = tuple(
-                type_name
-                for type_name in (_type_name(type_node) for type_node in type_nodes)
-                if type_name is not None
+                dict.fromkeys(
+                    _normalize_type_name(type_name)
+                    for type_name in (_type_name(type_node) for type_node in type_nodes)
+                    if type_name is not None
+                )
             )
             fused_types[name] = PyiFusedType(name, concrete_types)
         return fused_types
@@ -300,7 +307,12 @@ class Converter:
             is_async=node.is_async_def,
             doc=doc if include_docstrings else None,
             decorators=get_decorators(source_code, node),
-            signature=_resolve_fused_signature(get_signature(node), fused_types or {}),
+            signature=_resolve_fused_signature(
+                _restore_fused_memoryview_annotations(
+                    get_signature(node), node, fused_types or {}
+                ),
+                fused_types or {},
+            ),
             type_comment=self._type_comment_for(node, tc),
         )
 
@@ -350,6 +362,42 @@ class Converter:
         return PyiAssignment(f"{node.name}: _TypeAlias = int")  # type: ignore
 
 
+def _restore_fused_memoryview_annotations(
+    signature: PyiSignature,
+    node: Nodes.CFuncDefNode | Nodes.DefNode,
+    fused_types: dict[str, PyiFusedType],
+) -> PyiSignature:
+    if not fused_types:
+        return signature
+
+    if isinstance(node, Nodes.CFuncDefNode):
+        arg_nodes = getattr(getattr(node, "declarator", None), "args", [])
+    else:
+        arg_nodes = getattr(node, "args", [])
+    for arg, arg_node in zip(signature.args, arg_nodes, strict=False):
+        fused_name = _fused_memoryview_name(arg_node, fused_types)
+        if arg.annotation == "memoryview" and fused_name is not None:
+            arg.annotation = fused_name
+
+    fused_name = _fused_memoryview_name(node, fused_types)
+    if signature.return_type == "memoryview" and fused_name is not None:
+        signature.return_type = fused_name
+
+    return signature
+
+
+def _fused_memoryview_name(
+    node: Nodes.Node, fused_types: dict[str, PyiFusedType]
+) -> str | None:
+    base_type = getattr(node, "base_type", None)
+    if not isinstance(base_type, Nodes.MemoryViewSliceTypeNode):
+        return None
+
+    scalar = getattr(base_type, "base_type_node", None)
+    name = getattr(scalar, "name", None)
+    return name if name in fused_types else None
+
+
 def _resolve_fused_signature(
     signature: PyiSignature, fused_types: dict[str, PyiFusedType]
 ) -> PyiSignature:
@@ -377,7 +425,9 @@ def _resolved_fused_annotation(
             continue
         param_count, used_as_return = usage[name]
         replacement = name
-        if (not used_as_return and param_count <= 1) or param_count == 0:
+        if "object" in fused_types[name].concrete_types:
+            replacement = "object"
+        elif (not used_as_return and param_count <= 1) or param_count == 0:
             replacement = " | ".join(fused_types[name].concrete_types)
         resolved = _replace_annotation_name(resolved, name, replacement)
     return resolved

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -19,6 +19,7 @@ from ..models.pyi_elements import (
     PyiAssignment,
     PyiFunction,
     PyiEnum,
+    PyiSignature,
 )
 from .signature import get_signature
 from .source_extraction import get_decorators, get_bases, get_metaclass, get_source
@@ -28,6 +29,27 @@ from .docstrings import docstring_to_string
 from .type_parsing import extract_type_from_base_type
 
 _CIMPORT_RE = re.compile(r"\bcimport\b")
+
+_C_TO_PYTHON = {
+    "char": "int",
+    "double": "float",
+    "long": "int",
+    "long double": "float",
+    "long long": "int",
+    "short": "int",
+    "signed char": "int",
+    "unsigned char": "int",
+    "unsigned int": "int",
+    "unsigned long": "int",
+    "unsigned long long": "int",
+    "unsigned short": "int",
+}
+
+
+@dataclass
+class PyiFusedType:
+    name: str
+    concrete_types: tuple[str, ...]
 
 
 @dataclass
@@ -224,6 +246,27 @@ class Converter:
             type_comment=self._type_comment_for(cdef_func, tc),
         )
 
+    def convert_fused_types(
+        self, fused_type_nodes: list[Nodes.FusedTypeNode]
+    ) -> dict[str, PyiFusedType]:
+        fused_types: dict[str, PyiFusedType] = {}
+        for node in fused_type_nodes:
+            name = getattr(node, "name")
+            type_nodes = getattr(node, "types")
+            concrete_types = tuple(
+                type_name
+                for type_name in (_type_name(type_node) for type_node in type_nodes)
+                if type_name is not None
+            )
+            fused_types[name] = PyiFusedType(name, concrete_types)
+        return fused_types
+
+    def convert_fused_type(self, fused_type: PyiFusedType) -> PyiAssignment:
+        concrete_types = ", ".join(fused_type.concrete_types)
+        return PyiAssignment(
+            f'{fused_type.name} = TypeVar("{fused_type.name}", {concrete_types})'
+        )
+
     def convert_py_func(
         self,
         node: Nodes.DefNode,
@@ -288,3 +331,17 @@ class Converter:
             return PyiEnum(enum_name=name, names=get_enum_names(node))
         # Make it usable as an alias for int
         return PyiAssignment(f"{node.name}: TypeAlias = int")  # type: ignore
+
+
+def _type_name(node: Nodes.Node) -> str | None:
+    if isinstance(node, Nodes.CSimpleBaseTypeNode):
+        module_path = getattr(node, "module_path")
+        name = getattr(node, "name")
+        return ".".join(module_path + [name])
+    if isinstance(node, Nodes.TemplatedTypeNode):
+        return _type_name(getattr(node, "base_type_node"))
+    return None
+
+
+def _normalize_type_name(type_name: str) -> str:
+    return _C_TO_PYTHON.get(type_name, type_name)

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -7,6 +7,7 @@ import ast
 import re
 
 from dataclasses import dataclass
+from collections.abc import Iterator
 
 from Cython.Compiler import Nodes
 
@@ -475,12 +476,11 @@ def _resolved_fused_annotation(
     return resolved
 
 
-def _scope_functions(scope: PyiScope) -> list[PyiFunction]:
-    """Return all functions in the scope, recursively descending into nested classes."""
-    functions = list(scope.functions)
+def _scope_functions(scope: PyiScope) -> Iterator[PyiFunction]:
+    """Yield all functions in the scope, recursively descending into nested classes."""
+    yield from scope.functions
     for class_ in scope.classes:
-        functions.extend(_scope_functions(class_.scope))
-    return functions
+        yield from _scope_functions(class_.scope)
 
 
 def _annotation_uses_name(annotation: str | None, name: str) -> bool:
@@ -497,10 +497,8 @@ def _annotation_parts(annotation: str) -> list[str]:
 
 def _type_name(node: Nodes.Node) -> str | None:
     """Return a dotted type name for a simple or templated base-type node, or None."""
+    while isinstance(node, Nodes.TemplatedTypeNode):
+        node = getattr(node, "base_type_node")
     if isinstance(node, Nodes.CSimpleBaseTypeNode):
-        module_path = getattr(node, "module_path")
-        name = getattr(node, "name")
-        return ".".join(module_path + [name])
-    if isinstance(node, Nodes.TemplatedTypeNode):
-        return _type_name(getattr(node, "base_type_node"))
+        return ".".join(getattr(node, "module_path") + [getattr(node, "name")])
     return None

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -88,7 +88,7 @@ class Converter:
             doc=doc if include_docstrings else None,
             imports=self.convert_imports(visitor.import_visitor, source_code)
             + [
-                PyiImport("from typing import Any, Callable, TypeAlias, TypedDict"),
+                PyiImport("from typing import Any, Any as _Any, TypeAlias as _TypeAlias, TypedDict"),
                 PyiImport("import numpy"),
             ],
             scope=self.convert_scope(
@@ -146,7 +146,7 @@ class Converter:
         cdef_assignments: list[PyiAssignment] = []
         for cdef_variable in visitor.cdef_variables:
             for name, base_type in get_cdef_variables(cdef_variable):
-                resolved_type = base_type if base_type else "Any"
+                resolved_type = base_type if base_type else "_Any"
                 cdef_assignments.append(PyiAssignment(f"{name}: {resolved_type}"))
 
         # Preserve source order across cdef and def functions
@@ -330,7 +330,7 @@ class Converter:
             name: str | None = node.name  # type: ignore
             return PyiEnum(enum_name=name, names=get_enum_names(node))
         # Make it usable as an alias for int
-        return PyiAssignment(f"{node.name}: TypeAlias = int")  # type: ignore
+        return PyiAssignment(f"{node.name}: _TypeAlias = int")  # type: ignore
 
 
 def _type_name(node: Nodes.Node) -> str | None:

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -385,6 +385,7 @@ def _restore_fused_memoryview_annotations(
     node: Nodes.CFuncDefNode | Nodes.DefNode,
     fused_types: dict[str, PyiFusedType],
 ) -> PyiSignature:
+    """Restore fused typedef names on memoryview annotations lost during signature extraction."""
     if not fused_types:
         return signature
 
@@ -407,6 +408,7 @@ def _restore_fused_memoryview_annotations(
 def _fused_memoryview_name(
     node: Nodes.Node, fused_types: dict[str, PyiFusedType]
 ) -> str | None:
+    """Return the fused typedef name backing a memoryview node, or None if not fused."""
     base_type = getattr(node, "base_type", None)
     if not isinstance(base_type, Nodes.MemoryViewSliceTypeNode):
         return None
@@ -419,6 +421,7 @@ def _fused_memoryview_name(
 def _resolve_fused_signature(
     signature: PyiSignature, fused_types: dict[str, PyiFusedType]
 ) -> PyiSignature:
+    """Rewrite a signature's fused-type annotations to their resolved Python form."""
     usage = _signature_fused_usage(signature, fused_types)
     for arg in signature.args:
         if arg.annotation is not None:
@@ -437,6 +440,7 @@ def _resolved_fused_annotation(
     usage: dict[str, tuple[int, bool]],
     fused_types: dict[str, PyiFusedType],
 ) -> str:
+    """Resolve a single annotation string using per-name fused usage and definitions."""
     resolved = annotation
     for name in fused_types:
         if not _annotation_uses_name(resolved, name):
@@ -454,6 +458,7 @@ def _resolved_fused_annotation(
 def _signature_fused_usage(
     signature: PyiSignature, fused_types: dict[str, PyiFusedType]
 ) -> dict[str, tuple[int, bool]]:
+    """Count param/return occurrences of each fused type name in a signature."""
     usage: dict[str, tuple[int, bool]] = {}
     for name in fused_types:
         param_count = sum(
@@ -468,6 +473,7 @@ def _signature_fused_usage(
 def _find_typevar_fused_types(
     scope: PyiScope, fused_types: dict[str, PyiFusedType]
 ) -> list[str]:
+    """Return fused type names actually referenced by any function signature in the scope."""
     used: list[str] = []
     for name in fused_types:
         for function in _scope_functions(scope):
@@ -478,12 +484,14 @@ def _find_typevar_fused_types(
 
 
 def _signature_uses_name(signature: PyiSignature, name: str) -> bool:
+    """Return True if the given name appears in any argument or return annotation."""
     return any(
         _annotation_uses_name(arg.annotation, name) for arg in signature.args
     ) or _annotation_uses_name(signature.return_type, name)
 
 
 def _scope_functions(scope: PyiScope) -> list[PyiFunction]:
+    """Return all functions in the scope, recursively descending into nested classes."""
     functions = list(scope.functions)
     for class_ in scope.classes:
         functions.extend(_scope_functions(class_.scope))
@@ -491,16 +499,19 @@ def _scope_functions(scope: PyiScope) -> list[PyiFunction]:
 
 
 def _scope_uses_typevar(scope: PyiScope) -> bool:
+    """Return True if the scope contains any TypeVar assignment."""
     return any("TypeVar(" in assignment.statement for assignment in scope.assignments)
 
 
 def _annotation_uses_name(annotation: str | None, name: str) -> bool:
+    """Return True if the given name appears as a part of the (union) annotation."""
     if annotation is None:
         return False
     return name in _annotation_parts(annotation)
 
 
 def _replace_annotation_name(annotation: str, name: str, replacement: str) -> str:
+    """Return the annotation with every occurrence of name replaced by replacement."""
     parts = [
         replacement if part == name else part for part in _annotation_parts(annotation)
     ]
@@ -508,10 +519,12 @@ def _replace_annotation_name(annotation: str, name: str, replacement: str) -> st
 
 
 def _annotation_parts(annotation: str) -> list[str]:
+    """Split a union annotation string into its stripped alternative parts."""
     return [part.strip() for part in annotation.split("|")]
 
 
 def _type_name(node: Nodes.Node) -> str | None:
+    """Return a dotted type name for a simple or templated base-type node, or None."""
     if isinstance(node, Nodes.CSimpleBaseTypeNode):
         module_path = getattr(node, "module_path")
         name = getattr(node, "name")
@@ -522,4 +535,5 @@ def _type_name(node: Nodes.Node) -> str | None:
 
 
 def _normalize_type_name(type_name: str) -> str:
+    """Map a raw C type name to its Python equivalent, leaving unknown names unchanged."""
     return _C_TO_PYTHON.get(type_name, type_name)

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -84,16 +84,15 @@ class Converter:
         """
         tc = type_comments or {}
         doc = docstring_to_string(visitor.node.doc) if visitor.node.doc else None
+        scope = self.convert_scope(visitor.scope, source_code, tc, include_docstrings)
+        typing_import = "from typing import Any, Any as _Any, TypeAlias as _TypeAlias, TypedDict"
+        if _scope_uses_typevar(scope):
+            typing_import += ", TypeVar"
         return PyiModule(
             doc=doc if include_docstrings else None,
             imports=self.convert_imports(visitor.import_visitor, source_code)
-            + [
-                PyiImport("from typing import Any, Any as _Any, TypeAlias as _TypeAlias, TypedDict"),
-                PyiImport("import numpy"),
-            ],
-            scope=self.convert_scope(
-                visitor.scope, source_code, tc, include_docstrings
-            ),
+            + [PyiImport(typing_import), PyiImport("import numpy")],
+            scope=scope,
         )
 
     def convert_imports(
@@ -135,6 +134,7 @@ class Converter:
         source_code: str,
         type_comments: dict[int, str] | None = None,
         include_docstrings: bool = True,
+        inherited_fused_types: dict[str, PyiFusedType] | None = None,
     ) -> PyiScope:
         """Convert a ScopeVisitor to a PyiScope.
 
@@ -143,7 +143,7 @@ class Converter:
         """
         tc = type_comments or {}
         local_fused_types = self.convert_fused_types(visitor.fused_types)
-        fused_types = local_fused_types
+        fused_types = {**(inherited_fused_types or {}), **local_fused_types}
 
         cdef_assignments: list[PyiAssignment] = []
         for cdef_variable in visitor.cdef_variables:
@@ -164,7 +164,9 @@ class Converter:
         py_funcs = [
             (
                 node.pos[1],
-                self.convert_py_func(node, source_code, tc, include_docstrings),
+                self.convert_py_func(
+                    node, source_code, tc, include_docstrings, fused_types
+                ),
             )
             for node in visitor.py_functions
         ]
@@ -181,24 +183,32 @@ class Converter:
 
         all_funcs_sorted = sorted(cdef_funcs + py_funcs, key=lambda t: t[0])
         functions = [f for _, f in all_funcs_sorted]
-
         structs_or_enums = [
             self.convert_struct_or_union(node, source_code)
             for node in visitor.cdef_structs_or_unions
         ]
+        classes = [
+            self.convert_class(
+                class_visitor, source_code, tc, include_docstrings, fused_types
+            )
+            for class_visitor in visitor.classes
+        ]
+        fused_typevar_names = _find_typevar_fused_types(
+            PyiScope(functions=functions, classes=classes), local_fused_types
+        )
 
         return PyiScope(
             assignments=[
+                self.convert_fused_type(fused_types[name])
+                for name in fused_typevar_names
+            ]
+            + [
                 self.convert_assignment(assignment, source_code)
                 for assignment in visitor.assignments
             ]
             + cdef_assignments,
             functions=functions,
-            classes=structs_or_enums
-            + [
-                self.convert_class(class_visitor, source_code, tc, include_docstrings)
-                for class_visitor in visitor.classes
-            ],
+            classes=structs_or_enums + classes,
             enums=[self.convert_enum(enum) for enum in visitor.enums],
         )
 
@@ -208,6 +218,7 @@ class Converter:
         source_code: str,
         type_comments: dict[int, str] | None = None,
         include_docstrings: bool = True,
+        inherited_fused_types: dict[str, PyiFusedType] | None = None,
     ) -> PyiClass:
         """Convert a ClassVisitor to a PyiClass."""
         tc = type_comments or {}
@@ -226,7 +237,7 @@ class Converter:
             metaclass=get_metaclass(class_visitor.node),
             decorators=get_decorators(source_code, class_visitor.node),
             scope=self.convert_scope(
-                class_visitor.scope, source_code, tc, include_docstrings
+                class_visitor.scope, source_code, tc, include_docstrings, inherited_fused_types
             ),
         )
 
@@ -278,6 +289,7 @@ class Converter:
         source_code: str,
         type_comments: dict[int, str] | None = None,
         include_docstrings: bool = True,
+        fused_types: dict[str, PyiFusedType] | None = None,
     ) -> PyiFunction:
         """Convert a Python function definition node to PyiFunction."""
         tc = type_comments or {}
@@ -288,7 +300,7 @@ class Converter:
             is_async=node.is_async_def,
             doc=doc if include_docstrings else None,
             decorators=get_decorators(source_code, node),
-            signature=get_signature(node),
+            signature=_resolve_fused_signature(get_signature(node), fused_types or {}),
             type_comment=self._type_comment_for(node, tc),
         )
 
@@ -383,6 +395,35 @@ def _signature_fused_usage(
         if param_count or used_as_return:
             usage[name] = (param_count, used_as_return)
     return usage
+
+
+def _find_typevar_fused_types(
+    scope: PyiScope, fused_types: dict[str, PyiFusedType]
+) -> list[str]:
+    used: list[str] = []
+    for name in fused_types:
+        for function in _scope_functions(scope):
+            if _signature_uses_name(function.signature, name):
+                used.append(name)
+                break
+    return used
+
+
+def _signature_uses_name(signature: PyiSignature, name: str) -> bool:
+    return any(
+        _annotation_uses_name(arg.annotation, name) for arg in signature.args
+    ) or _annotation_uses_name(signature.return_type, name)
+
+
+def _scope_functions(scope: PyiScope) -> list[PyiFunction]:
+    functions = list(scope.functions)
+    for class_ in scope.classes:
+        functions.extend(_scope_functions(class_.scope))
+    return functions
+
+
+def _scope_uses_typevar(scope: PyiScope) -> bool:
+    return any("TypeVar(" in assignment.statement for assignment in scope.assignments)
 
 
 def _annotation_uses_name(annotation: str | None, name: str) -> bool:

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -152,6 +152,16 @@ class Converter:
 
         Preserves source order by interleaving cdef and def functions by their
         line position, rather than emitting all cdef functions first.
+
+        The ``emit_inherited_fused_typevars`` flag encodes a scope-role
+        distinction: which scope owns emitting ``TypeVar``/``TypeAlias``
+        assignments for fused typedefs that were inherited from a parent
+        (currently: the companion ``.pxd``, threaded in via
+        ``inherited_fused_types``). Exactly one scope in a nesting chain must
+        own that emission; emitting in more than one place produces
+        duplicate, incorrect ``TypeVar`` declarations. Only the outermost scope
+        (``convert_module``) should emit them. This solution is not the most elegant,
+        but it is a sufficient encoding for differentiating modules and classes today.
         """
         tc = type_comments or {}
         local_fused_types = self.convert_fused_types(visitor.fused_types)
@@ -396,7 +406,18 @@ def _restore_fused_memoryview_annotations(
     node: Nodes.CFuncDefNode | Nodes.DefNode,
     fused_types: dict[str, PyiFusedType],
 ) -> PyiSignature:
-    """Restore fused typedef names on memoryview annotations lost during signature extraction."""
+    """Restore fused typedef names on memoryview annotations lost during signature extraction.
+
+    This post-processing pass is a workaround for the fact that fused types are not
+    natively supported throughout the rest of stubgen-pyx's type-parsing and
+    signature-extraction machinery. If fused types were threaded into
+    _extract_memoryview_type we could preserve the fused typedef name there, but that
+    would require treating fused types as the first-class type concept throughout
+    the type-parsing layer, which is a much larger refactor. Instead, this pass
+    walks the original AST alongside the extracted signature and repairs any memoryview
+    annotations that were flattened to the string "memoryview" back to their fused
+    typedef name, so that the downstream fused-type resolver can handle them correctly.
+    """
     if not fused_types:
         return signature
 
@@ -432,7 +453,21 @@ def _fused_memoryview_name(
 def _resolve_fused_signature(
     signature: PyiSignature, fused_types: dict[str, PyiFusedType]
 ) -> PyiSignature:
-    """Rewrite a signature's fused-type annotations to their resolved Python form."""
+    """Rewrite a signature's fused-type annotations to their resolved Python form.
+
+    Having the AST layer natively handle fused resolution would require the
+    ``PyiSignature`` model to carry structured fused references rather than
+    strings, and every downstream consumer (import emission,
+    ``trim_not_defined``, source rendering) would need to handle those gracefully.
+    Doing so is a much larger refactor. To avoid that, this function is a localized
+    post-processing pass that rewrites the signature's argument and return annotations
+    after the AST traversal has completed by introspecting the already-generated
+    annotation strings and the fused-type definitions. A fused typedef like ``numeric``
+    resolves to a ``TypeVar`` when it appears in both a parameter and the return, to a
+    ``|``-union when it appears in one parameter only, or to ``object`` when its member
+    set includes ``object``. That decision is a *whole-signature* property, so it cannot
+    be made while an individual argument's annotation is being generated.
+    """
     usage: dict[str, tuple[int, bool]] = {}
     for name in fused_types:
         param_count = sum(

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -93,7 +93,9 @@ class Converter:
             inherited_fused_types,
             emit_inherited_fused_typevars=True,
         )
-        typing_import = "from typing import Any, Any as _Any, TypeAlias as _TypeAlias, TypedDict"
+        typing_import = (
+            "from typing import Any, Any as _Any, TypeAlias as _TypeAlias, TypedDict"
+        )
         if _scope_uses_typevar(scope):
             typing_import += ", TypeVar"
         return PyiModule(
@@ -249,7 +251,11 @@ class Converter:
             metaclass=get_metaclass(class_visitor.node),
             decorators=get_decorators(source_code, class_visitor.node),
             scope=self.convert_scope(
-                class_visitor.scope, source_code, tc, include_docstrings, inherited_fused_types
+                class_visitor.scope,
+                source_code,
+                tc,
+                include_docstrings,
+                inherited_fused_types,
             ),
         )
 

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -19,6 +19,7 @@ from ..models.pyi_elements import (
     PyiAssignment,
     PyiFunction,
     PyiEnum,
+    PyiSignature,
 )
 from .signature import get_signature
 from .conversion_utils import (
@@ -33,6 +34,12 @@ from .conversion_utils import (
 )
 
 _CIMPORT_RE = re.compile(r"\bcimport\b")
+
+
+@dataclass
+class PyiFusedType:
+    name: str
+    concrete_types: tuple[str, ...]
 
 
 @dataclass
@@ -67,13 +74,17 @@ class Converter:
         """
         tc = type_comments or {}
         doc = docstring_to_string(visitor.node.doc) if visitor.node.doc else None
+        scope = self.convert_scope(
+            visitor.scope, source_code, tc, include_docstrings
+        )
+        typing_import = "from typing import Any as _Any, TypeAlias as _TypeAlias"
+        if _scope_uses_typevar(scope):
+            typing_import += ", TypeVar"
         return PyiModule(
             doc=doc if include_docstrings else None,
             imports=self.convert_imports(visitor.import_visitor, source_code)
-            + [PyiImport("from typing import Any as _Any, TypeAlias as _TypeAlias")],
-            scope=self.convert_scope(
-                visitor.scope, source_code, tc, include_docstrings
-            ),
+            + [PyiImport(typing_import)],
+            scope=scope,
         )
 
     def convert_imports(
@@ -100,6 +111,7 @@ class Converter:
         line position, rather than emitting all cdef functions first.
         """
         tc = type_comments or {}
+        fused_types = self.convert_fused_types(visitor.fused_types)
 
         cdef_assignments: list[PyiAssignment] = []
         for cdef_variable in visitor.cdef_variables:
@@ -111,7 +123,9 @@ class Converter:
         cdef_funcs = [
             (
                 node.pos[1],
-                self.convert_cdef_func(node, source_code, tc, include_docstrings),
+                self.convert_cdef_func(
+                    node, source_code, tc, include_docstrings, fused_types
+                ),
             )
             for node in visitor.cdef_functions
         ]
@@ -124,9 +138,17 @@ class Converter:
         ]
         all_funcs_sorted = sorted(cdef_funcs + py_funcs, key=lambda t: t[0])
         functions = [f for _, f in all_funcs_sorted]
+        if functions:
+            fused_typevar_names = _find_typevar_fused_types(functions, fused_types)
+        else:
+            fused_typevar_names = list(fused_types)
 
         return PyiScope(
             assignments=[
+                self.convert_fused_type(fused_types[name])
+                for name in fused_typevar_names
+            ]
+            + [
                 self.convert_assignment(assignment, source_code)
                 for assignment in visitor.assignments
             ]
@@ -174,6 +196,7 @@ class Converter:
         source_code: str,
         type_comments: dict[int, str] | None = None,
         include_docstrings: bool = True,
+        fused_types: dict[str, PyiFusedType] | None = None,
     ) -> PyiFunction:
         """Convert a C function definition node to PyiFunction."""
         tc = type_comments or {}
@@ -184,8 +207,31 @@ class Converter:
             is_async=False,
             doc=doc if include_docstrings else None,
             decorators=get_decorators(source_code, cdef_func),
-            signature=get_signature(cdef_func),
+            signature=_resolve_fused_signature(
+                get_signature(cdef_func), fused_types or {}
+            ),
             type_comment=self._type_comment_for(cdef_func, tc),
+        )
+
+    def convert_fused_types(
+        self, fused_type_nodes: list[Nodes.FusedTypeNode]
+    ) -> dict[str, PyiFusedType]:
+        fused_types: dict[str, PyiFusedType] = {}
+        for node in fused_type_nodes:
+            name = getattr(node, "name")
+            type_nodes = getattr(node, "types")
+            concrete_types = tuple(
+                type_name
+                for type_name in (_type_name(type_node) for type_node in type_nodes)
+                if type_name is not None
+            )
+            fused_types[name] = PyiFusedType(name, concrete_types)
+        return fused_types
+
+    def convert_fused_type(self, fused_type: PyiFusedType) -> PyiAssignment:
+        concrete_types = ", ".join(fused_type.concrete_types)
+        return PyiAssignment(
+            f'{fused_type.name} = TypeVar("{fused_type.name}", {concrete_types})'
         )
 
     def convert_py_func(
@@ -214,7 +260,7 @@ class Converter:
         """Convert an assignment node to PyiAssignment, extracting type annotations."""
         if isinstance(assignment, Nodes.SingleAssignmentNode):
             expr = unparse_expr(assignment.rhs)
-            name: str = assignment.lhs.name  # type: ignore
+            name: str = assignment.lhs.name
             if expr != "...":
                 annotation = (
                     assignment.lhs.annotation.string.value
@@ -248,7 +294,7 @@ class Converter:
             if not isinstance(node, Nodes.CSimpleBaseTypeNode):
                 return PyiAssignment(f"{name} = ...")
 
-            base_name: str = node.name  # type: ignore
+            base_name: str = node.name
             type_name = ".".join(node.module_path + [base_name])
             return PyiAssignment(f"{name}: _TypeAlias = {type_name}")
 
@@ -261,3 +307,70 @@ class Converter:
             return PyiEnum(enum_name=name, names=get_enum_names(node))
         # Make it usable as an alias for int
         return PyiAssignment(f"{node.name}: _TypeAlias = int")  # type: ignore
+
+
+def _type_name(node: Nodes.Node) -> str | None:
+    if isinstance(node, Nodes.CSimpleBaseTypeNode):
+        module_path = getattr(node, "module_path")
+        name = getattr(node, "name")
+        return ".".join(module_path + [name])
+    if isinstance(node, Nodes.TemplatedTypeNode):
+        return _type_name(getattr(node, "base_type_node"))
+    return None
+
+
+def _resolve_fused_signature(
+    signature: PyiSignature, fused_types: dict[str, PyiFusedType]
+) -> PyiSignature:
+    usage = _signature_fused_usage(signature, fused_types)
+    for arg in signature.args:
+        if arg.annotation in fused_types:
+            arg.annotation = _resolved_fused_annotation(arg.annotation, usage, fused_types)
+    if signature.return_type in fused_types:
+        signature.return_type = _resolved_fused_annotation(
+            signature.return_type, usage, fused_types
+        )
+    return signature
+
+
+def _resolved_fused_annotation(
+    name: str,
+    usage: dict[str, tuple[int, bool]],
+    fused_types: dict[str, PyiFusedType],
+) -> str:
+    param_count, used_as_return = usage[name]
+    if used_as_return or param_count > 1:
+        return name
+    return " | ".join(fused_types[name].concrete_types)
+
+
+def _signature_fused_usage(
+    signature: PyiSignature, fused_types: dict[str, PyiFusedType]
+) -> dict[str, tuple[int, bool]]:
+    usage: dict[str, tuple[int, bool]] = {}
+    for name in fused_types:
+        param_count = sum(arg.annotation == name for arg in signature.args)
+        used_as_return = signature.return_type == name
+        if param_count or used_as_return:
+            usage[name] = (param_count, used_as_return)
+    return usage
+
+
+def _find_typevar_fused_types(
+    functions: list[PyiFunction], fused_types: dict[str, PyiFusedType]
+) -> list[str]:
+    used: list[str] = []
+    for name in fused_types:
+        for function in functions:
+            if _signature_uses_name(function.signature, name):
+                used.append(name)
+                break
+    return used
+
+
+def _signature_uses_name(signature: PyiSignature, name: str) -> bool:
+    return any(arg.annotation == name for arg in signature.args) or signature.return_type == name
+
+
+def _scope_uses_typevar(scope: PyiScope) -> bool:
+    return any("TypeVar(" in assignment.statement for assignment in scope.assignments)

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -22,6 +22,7 @@ from ..models.pyi_elements import (
     PyiEnum,
     PyiSignature,
 )
+from ..postprocessing.normalize_names import _CYTHON_TRANSLATIONS
 from .signature import get_signature
 from .source_extraction import get_decorators, get_bases, get_metaclass, get_source
 from .declarators import get_enum_names, get_cdef_variables
@@ -30,21 +31,6 @@ from .docstrings import docstring_to_string
 from .type_parsing import extract_type_from_base_type
 
 _CIMPORT_RE = re.compile(r"\bcimport\b")
-
-_C_TO_PYTHON = {
-    "char": "int",
-    "double": "float",
-    "long": "int",
-    "long double": "float",
-    "long long": "int",
-    "short": "int",
-    "signed char": "int",
-    "unsigned char": "int",
-    "unsigned int": "int",
-    "unsigned long": "int",
-    "unsigned long long": "int",
-    "unsigned short": "int",
-}
 
 
 @dataclass
@@ -315,7 +301,7 @@ class Converter:
             type_nodes = getattr(node, "types")
             concrete_types = tuple(
                 dict.fromkeys(
-                    _C_TO_PYTHON.get(type_name, type_name)
+                    _CYTHON_TRANSLATIONS.get(type_name, type_name)
                     for type_name in (_type_name(type_node) for type_node in type_nodes)
                     if type_name is not None
                 )

--- a/stubgen_pyx/postprocessing/normalize_names.py
+++ b/stubgen_pyx/postprocessing/normalize_names.py
@@ -50,6 +50,14 @@ _CYTHON_TRANSLATIONS: dict[str, str] = {
     "bint": "bool",
     "unicode": "str",
     "void": "None",
+    "long double": "float",
+    "long long": "int",
+    "signed char": "int",
+    "unsigned char": "int",
+    "unsigned int": "int",
+    "unsigned long": "int",
+    "unsigned long long": "int",
+    "unsigned short": "int",
 }
 
 for int_type in _CYTHON_INTS:

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -107,6 +107,18 @@ class StubgenPyx:
         converter = self._make_converter()
 
         module_name = path_to_module_name(pyx_path) if pyx_path else None
+        pxd_parse_result = None
+        pxd_visitor = None
+        pxd_fused_types = None
+        if pxd_str and self.config.pxd_to_stubs:
+            pxd_parse_result = parse_pyx(
+                pxd_str, module_name=module_name, pyx_path=pyx_path, pxd=True
+            )
+            pxd_visitor = ModuleVisitor(node=pxd_parse_result.source_ast)
+            pxd_fused_types = converter.convert_fused_types(
+                pxd_visitor.scope.fused_types
+            )
+
         parse_result = parse_pyx(pyx_str, module_name=module_name, pyx_path=pyx_path)
 
         module_visitor = ModuleVisitor(node=parse_result.source_ast)
@@ -115,13 +127,10 @@ class StubgenPyx:
             parse_result.source,
             parse_result.type_comments,
             include_docstrings=self.config.include_docstrings,
+            inherited_fused_types=pxd_fused_types,
         )
 
-        if pxd_str and self.config.pxd_to_stubs:
-            pxd_parse_result = parse_pyx(
-                pxd_str, module_name=module_name, pyx_path=pyx_path, pxd=True
-            )
-            pxd_visitor = ModuleVisitor(node=pxd_parse_result.source_ast)
+        if pxd_parse_result is not None and pxd_visitor is not None:
             pxd_module = converter.convert_module(
                 pxd_visitor,
                 pxd_parse_result.source,

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -107,6 +107,14 @@ class StubgenPyx:
         converter = self._make_converter()
 
         module_name = path_to_module_name(pyx_path) if pyx_path else None
+        # Full fused type support including cross-file inheritance would require
+        # Cython's own scope/env for symbol resolution, which is not currently available
+        # in this generator. Making that available would require a significant refactor,
+        # so in lieu of that we restrict the code to only handle the companion .pxd file
+        # (same stem) by parsing it as a separate pre-pass and merging its fused
+        # typedefs into the .pyx conversion. This is a pragmatic compromise that covers
+        # the majority of real-world use cases. Fused typedefs made visible via
+        # `cimport` from an unrelated module are not resolved through this path.
         pxd_parse_result = None
         pxd_visitor = None
         pxd_fused_types = None

--- a/tests/test_fused_types.py
+++ b/tests/test_fused_types.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from stubgen_pyx.analysis.visitor import ScopeVisitor
+from stubgen_pyx.parsing.parser import parse_pyx
+
+
+def test_scope_visitor_collects_fused_typedef():
+    parsed = parse_pyx(
+        """
+ctypedef fused ColumnOrTable:
+    Column
+    Table
+"""
+    )
+
+    visitor = ScopeVisitor(parsed.source_ast)
+
+    assert len(visitor.fused_types) == 1
+    assert getattr(visitor.fused_types[0], "name") == "ColumnOrTable"

--- a/tests/test_fused_types.py
+++ b/tests/test_fused_types.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from textwrap import dedent, indent
 
-import pytest
-
 from stubgen_pyx import StubgenPyx
 from stubgen_pyx.config import StubgenPyxConfig
 
@@ -41,25 +39,29 @@ _FOOBAR_FUSED = _ctypedef_fused("FooOrBar", "Foo", "Bar")
 _FOOBAR_PREAMBLE = _FOOBAR_CLASSES + _FOOBAR_FUSED
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_single_param_unrelated_return_becomes_union():
     """One fused-typed parameter with an unrelated return -> Union annotation."""
-    result = _stubgen().convert_str(_FOOBAR_PREAMBLE + _cy("""
+    result = _stubgen().convert_str(
+        _FOOBAR_PREAMBLE
+        + _cy("""
         cpdef Foo f(FooOrBar x):
             pass
-    """))
+    """)
+    )
     assert "def f(x: Foo | Bar) -> Foo" in result
     assert "x: ..." not in result
     assert "TypeVar" not in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_param_and_return_correlated_becomes_typevar():
     """Fused type in both param and return -> TypeVar to preserve correlation."""
-    result = _stubgen().convert_str(_FOOBAR_PREAMBLE + _cy("""
+    result = _stubgen().convert_str(
+        _FOOBAR_PREAMBLE
+        + _cy("""
         cpdef FooOrBar f(FooOrBar x):
             pass
-    """))
+    """)
+    )
     assert "from typing import TypeVar" in result
     assert "FooOrBar = TypeVar('FooOrBar', Foo, Bar)" in result
     assert "def f(x: FooOrBar) -> FooOrBar" in result
@@ -69,42 +71,47 @@ def test_param_and_return_correlated_becomes_typevar():
     assert "fused" not in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_multiple_params_same_fused_type_becomes_typevar():
     """Two params sharing a fused type must be the same concrete type -> TypeVar."""
-    result = _stubgen().convert_str(_FOOBAR_PREAMBLE + _cy("""
+    result = _stubgen().convert_str(
+        _FOOBAR_PREAMBLE
+        + _cy("""
         cpdef int f(FooOrBar x, FooOrBar y):
             pass
-    """))
+    """)
+    )
     assert "from typing import TypeVar" in result
     assert "FooOrBar = TypeVar('FooOrBar', Foo, Bar)" in result
     assert "def f(x: FooOrBar, y: FooOrBar) -> int" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_return_only_fused_type_becomes_union():
     """Return-only fused type has no param to correlate, so it degrades to a Union."""
-    result = _stubgen().convert_str(_FOOBAR_PREAMBLE + _cy("""
+    result = _stubgen().convert_str(
+        _FOOBAR_PREAMBLE
+        + _cy("""
         cpdef FooOrBar f():
             pass
-    """))
+    """)
+    )
     assert "def f() -> Foo | Bar" in result
     assert "-> ..." not in result
     assert "TypeVar" not in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_fused_param_with_none_default_becomes_optional_union():
     """A single fused param defaulting to None -> ``Foo | Bar | None``."""
-    result = _stubgen().convert_str(_FOOBAR_PREAMBLE + _cy("""
+    result = _stubgen().convert_str(
+        _FOOBAR_PREAMBLE
+        + _cy("""
         cpdef int f(FooOrBar x = None):
             pass
-    """))
+    """)
+    )
     assert "def f(x: Foo | Bar | None=None) -> int" in result
     assert "x: ..." not in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_two_distinct_fused_types_in_one_signature():
     """Different fused types in the same signature are resolved independently."""
     result = _stubgen().convert_str(
@@ -123,7 +130,6 @@ def test_two_distinct_fused_types_in_one_signature():
     assert "def f(x: FooOrBar, y: X | Y) -> FooOrBar" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_multiple_independent_fused_types_both_stay_union():
     """Two different fused types, each used only as a single param, both stay Union."""
     result = _stubgen().convert_str(
@@ -139,35 +145,38 @@ def test_multiple_independent_fused_types_both_stay_union():
     assert "TypeVar" not in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_method_single_fused_param_becomes_union():
     """``self`` must not count towards the fused-type usage tally."""
     result = _stubgen().convert_str(
         _FOOBAR_PREAMBLE
-        + _class_wrap("Ops", """
+        + _class_wrap(
+            "Ops",
+            """
             cpdef Foo f(self, FooOrBar x):
                 pass
-        """)
+        """,
+        )
     )
     assert "def f(self, x: Foo | Bar) -> Foo" in result
     assert "TypeVar" not in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_method_correlated_fused_type_uses_typevar():
     """Fused type across method param + return correlates via TypeVar."""
     result = _stubgen().convert_str(
         _FOOBAR_PREAMBLE
-        + _class_wrap("Ops", """
+        + _class_wrap(
+            "Ops",
+            """
             cpdef FooOrBar f(self, FooOrBar x):
                 pass
-        """)
+        """,
+        )
     )
     assert "FooOrBar = TypeVar('FooOrBar', Foo, Bar)" in result
     assert "def f(self, x: FooOrBar) -> FooOrBar" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_method_and_module_function_share_typevar_definition():
     """Use same fused type in free function and method Module-level Union."""
     result = _stubgen().convert_str(
@@ -176,46 +185,53 @@ def test_method_and_module_function_share_typevar_definition():
             cpdef int f(FooOrBar x):
                 pass
         """)
-        + _class_wrap("Ops", """
+        + _class_wrap(
+            "Ops",
+            """
             cpdef FooOrBar g(self, FooOrBar x):
                 pass
-        """)
+        """,
+        )
     )
     assert result.count("FooOrBar = TypeVar('FooOrBar', Foo, Bar)") == 1
     assert "def f(x: Foo | Bar) -> int" in result
     assert "def g(self, x: FooOrBar) -> FooOrBar" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_def_function_single_fused_param_becomes_union():
     """``def`` functions follow the same Union heuristic as ``cpdef``."""
-    result = _stubgen().convert_str(_FOOBAR_PREAMBLE + _cy("""
+    result = _stubgen().convert_str(
+        _FOOBAR_PREAMBLE
+        + _cy("""
         def f(FooOrBar x):
             pass
-    """))
+    """)
+    )
     assert "def f(x: Foo | Bar)" in result
     assert "TypeVar" not in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_cdef_c_only_function_with_fused_param_is_skipped():
     """``cdef`` functions must never appear in the stub."""
-    result = _stubgen().convert_str(_FOOBAR_PREAMBLE + _cy("""
+    result = _stubgen().convert_str(
+        _FOOBAR_PREAMBLE
+        + _cy("""
         cdef int f(FooOrBar x):
             pass
 
         cpdef int g(FooOrBar x):
             pass
-    """))
+    """)
+    )
     assert "def f(" not in result
     assert "def g(x: Foo | Bar) -> int" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_pxd_declared_fused_type_used_by_pyx_becomes_typevar():
     """Fused type from companion .pxd is resolved like a locally-declared one."""
     result = _stubgen().convert_str(
-        _FOOBAR_CLASSES + _cy("""
+        _FOOBAR_CLASSES
+        + _cy("""
             cpdef FooOrBar f(FooOrBar x):
                 pass
         """),
@@ -225,11 +241,11 @@ def test_pxd_declared_fused_type_used_by_pyx_becomes_typevar():
     assert "def f(x: FooOrBar) -> FooOrBar" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_pxd_declared_fused_type_single_param_becomes_union():
     """Union heuristic still applies when the fused type comes from the pxd."""
     result = _stubgen().convert_str(
-        _FOOBAR_CLASSES + _cy("""
+        _FOOBAR_CLASSES
+        + _cy("""
             cpdef int f(FooOrBar x):
                 pass
         """),
@@ -239,13 +255,10 @@ def test_pxd_declared_fused_type_single_param_becomes_union():
     assert "TypeVar" not in result
 
 
-
-@pytest.mark.xfail(
-    reason="Cython primitive aliasing produces duplicate TypeVar entries", strict=True
-)
 def test_cython_numeric_primitives_deduplicated():
     """``int``, ``long``, ``long long`` all map to Python ``int`` and must be deduplicated."""
-    result = _stubgen().convert_str(_cy("""
+    result = _stubgen().convert_str(
+        _cy("""
         ctypedef fused integral_t:
             int
             long
@@ -254,17 +267,18 @@ def test_cython_numeric_primitives_deduplicated():
 
         cpdef integral_t f(integral_t x, integral_t y):
             pass
-    """))
+    """)
+    )
     assert "integral_t" in result
     assert "x: ..." not in result
     assert "-> ..." not in result
     assert "TypeVar('integral_t', int, int" not in result
 
 
-@pytest.mark.xfail(reason="Cython float/double both alias Python float", strict=True)
 def test_cython_float_primitives_deduplicated():
     """``float`` and ``double`` both map to Python ``float`` and must be deduplicated."""
-    result = _stubgen().convert_str(_cy("""
+    result = _stubgen().convert_str(
+        _cy("""
         ctypedef fused numeric_t:
             int
             float
@@ -272,7 +286,8 @@ def test_cython_float_primitives_deduplicated():
 
         cpdef numeric_t f(numeric_t x):
             pass
-    """))
+    """)
+    )
     assert "x: ..." not in result
     assert "-> ..." not in result
     assert "numeric_t = TypeVar('numeric_t', int, float)" in result
@@ -281,22 +296,22 @@ def test_cython_float_primitives_deduplicated():
     assert "TypeVar('numeric_t', float, float" not in result
 
 
-@pytest.mark.xfail(reason="typed memoryview fused annotations are dropped", strict=True)
 def test_fused_typed_memoryview_annotation_preserved():
     """``numeric[:]`` typed memoryviews with fused element types must keep an annotation."""
-    result = _stubgen().convert_str(_cy("""
+    result = _stubgen().convert_str(
+        _cy("""
         ctypedef fused numeric:
             int
             float
 
         cpdef numeric[:] f(numeric[:] x):
             pass
-    """))
+    """)
+    )
     assert "def f(x)" not in result
     assert "TypeVar" in result or "|" in result
 
 
-@pytest.mark.xfail(reason="fused type with object member not resolved", strict=True)
 def test_fused_type_with_object_member():
     """``object`` as a fused member absorbs the other members — accepted type collapses to ``object``."""
     result = _stubgen().convert_str(
@@ -312,7 +327,6 @@ def test_fused_type_with_object_member():
     assert "Foo | Bar | object" not in result
 
 
-@pytest.mark.xfail(reason="fused type with list member not resolved", strict=True)
 def test_fused_type_with_list_member():
     """``list`` as a fused member — Union must include the builtin."""
     result = _stubgen().convert_str(
@@ -327,9 +341,6 @@ def test_fused_type_with_list_member():
     assert "x: ..." not in result
 
 
-@pytest.mark.xfail(
-    reason="fused type mixing extension type and C primitive not resolved", strict=True
-)
 def test_fused_type_mixing_extension_and_c_primitive():
     """Extension type + C primitive as fused members — primitive maps to ``int``."""
     result = _stubgen().convert_str(
@@ -344,13 +355,11 @@ def test_fused_type_mixing_extension_and_c_primitive():
     assert "x: ..." not in result
 
 
-@pytest.mark.xfail(
-    reason="pxd-declared fused param with star default not resolved", strict=True
-)
 def test_pxd_fused_param_with_star_default_becomes_optional_union():
     """pxd forward decl with ``= *`` default on fused param — impl has real default; stub must resolve annotation."""
     result = _stubgen().convert_str(
-        _FOOBAR_CLASSES + _cy("""
+        _FOOBAR_CLASSES
+        + _cy("""
             cpdef int f(FooOrBar x = None):
                 pass
         """),
@@ -360,7 +369,6 @@ def test_pxd_fused_param_with_star_default_becomes_optional_union():
     assert "x: ..." not in result
 
 
-@pytest.mark.xfail(reason="fused type with enum member not resolved", strict=True)
 def test_fused_type_with_enum_member():
     """Extension type + ``cdef enum`` as fused members — enum survives in Union."""
     result = _stubgen().convert_str(
@@ -380,10 +388,11 @@ def test_fused_type_with_enum_member():
     assert "x: ..." not in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_typevar_shared_across_module_functions_only():
     """Many top-level fns sharing a fused type — one TypeVar decl."""
-    result = _stubgen().convert_str(_FOOBAR_PREAMBLE + _cy("""
+    result = _stubgen().convert_str(
+        _FOOBAR_PREAMBLE
+        + _cy("""
         cpdef FooOrBar f(FooOrBar x):
             pass
 
@@ -392,25 +401,27 @@ def test_typevar_shared_across_module_functions_only():
 
         cpdef FooOrBar h(FooOrBar x):
             pass
-    """))
+    """)
+    )
     assert result.count("FooOrBar = TypeVar('FooOrBar', Foo, Bar)") == 1
     assert "def f(x: FooOrBar) -> FooOrBar" in result
     assert "def g(x: FooOrBar) -> FooOrBar" in result
     assert "def h(x: FooOrBar) -> FooOrBar" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_fused_correlate_with_extra_non_fused_params():
     """Fused param + fused return alongside non-fused params — TypeVar still correlates."""
-    result = _stubgen().convert_str(_FOOBAR_PREAMBLE + _cy("""
+    result = _stubgen().convert_str(
+        _FOOBAR_PREAMBLE
+        + _cy("""
         cpdef FooOrBar f(FooOrBar x, int extra, Foo other):
             pass
-    """))
+    """)
+    )
     assert "FooOrBar = TypeVar('FooOrBar', Foo, Bar)" in result
     assert "def f(x: FooOrBar, extra: int, other: Foo) -> FooOrBar" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_four_member_fused_type_union_and_typevar():
     """4-member fused type — Union/TypeVar render all members in order."""
     result = _stubgen().convert_str(
@@ -429,11 +440,11 @@ def test_four_member_fused_type_union_and_typevar():
     assert "def correlate(x: Quad) -> Quad" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_pxd_declared_fused_type_shared_across_module_functions():
     """Multiple pxd fwd decls sharing a pxd-declared fused type — one TypeVar decl."""
     result = _stubgen().convert_str(
-        _FOOBAR_CLASSES + _cy("""
+        _FOOBAR_CLASSES
+        + _cy("""
             cpdef FooOrBar f(FooOrBar x):
                 pass
 
@@ -443,7 +454,8 @@ def test_pxd_declared_fused_type_shared_across_module_functions():
             cpdef FooOrBar h(FooOrBar x):
                 pass
         """),
-        pxd_str=_FOOBAR_FUSED + _cy("""
+        pxd_str=_FOOBAR_FUSED
+        + _cy("""
             cpdef FooOrBar f(FooOrBar x)
             cpdef FooOrBar g(FooOrBar x)
             cpdef FooOrBar h(FooOrBar x)
@@ -455,15 +467,19 @@ def test_pxd_declared_fused_type_shared_across_module_functions():
     assert "def h(x: FooOrBar) -> FooOrBar" in result
 
 
-@pytest.mark.xfail(reason="fused type support not yet implemented", strict=True)
 def test_pxd_declared_fused_type_used_by_pyx_method():
     """Class method using pxd-declared fused type — method-level resolution + pxd inheritance combined."""
     result = _stubgen().convert_str(
-        _FOOBAR_CLASSES + _class_wrap("Ops", """
+        _FOOBAR_CLASSES
+        + _class_wrap(
+            "Ops",
+            """
             cpdef FooOrBar f(self, FooOrBar x):
                 pass
-        """),
-        pxd_str=_FOOBAR_FUSED + _class_wrap("Ops", "cpdef FooOrBar f(self, FooOrBar x)"),
+        """,
+        ),
+        pxd_str=_FOOBAR_FUSED
+        + _class_wrap("Ops", "cpdef FooOrBar f(self, FooOrBar x)"),
     )
     assert result.count("FooOrBar = TypeVar('FooOrBar', Foo, Bar)") == 1
     assert "def f(self, x: FooOrBar) -> FooOrBar" in result

--- a/tests/test_fused_types.py
+++ b/tests/test_fused_types.py
@@ -256,7 +256,7 @@ def test_pxd_declared_fused_type_single_param_becomes_union():
 
 
 def test_cython_numeric_primitives_deduplicated():
-    """``int``, ``long``, ``long long`` all map to Python ``int`` and must be deduplicated."""
+    """C primitives that map to Python ``int`` (single- and multi-word spellings) must deduplicate."""
     result = _stubgen().convert_str(
         _cy("""
         ctypedef fused integral_t:
@@ -264,25 +264,31 @@ def test_cython_numeric_primitives_deduplicated():
             long
             long long
             unsigned int
+            unsigned char
+            unsigned short
+            unsigned long
+            unsigned long long
+            signed char
+            size_t
 
         cpdef integral_t f(integral_t x, integral_t y):
             pass
     """)
     )
-    assert "integral_t" in result
-    assert "x: ..." not in result
-    assert "-> ..." not in result
-    assert "TypeVar('integral_t', int, int" not in result
+    assert "integral_t = TypeVar('integral_t', int)" in result
+    assert "def f(x: integral_t, y: integral_t) -> integral_t" in result
+    assert "int, int" not in result
 
 
 def test_cython_float_primitives_deduplicated():
-    """``float`` and ``double`` both map to Python ``float`` and must be deduplicated."""
+    """C primitives that map to Python ``float`` (including multi-word ``long double``) must deduplicate."""
     result = _stubgen().convert_str(
         _cy("""
         ctypedef fused numeric_t:
             int
             float
             double
+            long double
 
         cpdef numeric_t f(numeric_t x):
             pass
@@ -292,8 +298,24 @@ def test_cython_float_primitives_deduplicated():
     assert "-> ..." not in result
     assert "numeric_t = TypeVar('numeric_t', int, float)" in result
     assert "def f(x: numeric_t) -> numeric_t" in result
-    assert "TypeVar('numeric_t', int, float, float" not in result
-    assert "TypeVar('numeric_t', float, float" not in result
+    assert "float, float" not in result
+
+
+def test_fused_unicode_and_str_deduplicated():
+    """``unicode`` maps to Python ``str`` and must deduplicate against a sibling ``str`` member."""
+    result = _stubgen().convert_str(
+        _cy("""
+        ctypedef fused string_t:
+            unicode
+            str
+
+        cpdef string_t f(string_t x):
+            pass
+    """)
+    )
+    assert "string_t = TypeVar('string_t', str)" in result
+    assert "def f(x: string_t) -> string_t" in result
+    assert "str, str" not in result
 
 
 def test_fused_typed_memoryview_annotation_preserved():

--- a/tests/test_fused_types.py
+++ b/tests/test_fused_types.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+from stubgen_pyx import StubgenPyx
 from stubgen_pyx.analysis.visitor import ScopeVisitor
+from stubgen_pyx.config import StubgenPyxConfig
 from stubgen_pyx.parsing.parser import parse_pyx
+
+
+def _stubgen() -> StubgenPyx:
+    return StubgenPyx(
+        StubgenPyxConfig(exclude_attribution=True, sort_imports=False)
+    )
 
 
 def test_scope_visitor_collects_fused_typedef():
@@ -17,3 +25,50 @@ ctypedef fused ColumnOrTable:
 
     assert len(visitor.fused_types) == 1
     assert getattr(visitor.fused_types[0], "name") == "ColumnOrTable"
+
+
+def test_simple_fused_parameter_uses_union_annotation():
+    result = _stubgen().convert_str(
+        """
+cdef class Column:
+    pass
+
+cdef class Scalar:
+    pass
+
+ctypedef fused ColumnOrScalar:
+    Column
+    Scalar
+
+cpdef Column take(ColumnOrScalar value):
+    pass
+"""
+    )
+
+    assert "def take(value: Column | Scalar) -> Column" in result
+    assert "value: ..." not in result
+
+
+def test_correlated_fused_parameter_and_return_uses_typevar():
+    result = _stubgen().convert_str(
+        """
+cdef class Column:
+    pass
+
+cdef class Table:
+    pass
+
+ctypedef fused ColumnOrTable:
+    Column
+    Table
+
+cpdef ColumnOrTable empty_like(ColumnOrTable input):
+    pass
+"""
+    )
+
+    assert "from typing import TypeVar" in result
+    assert "ColumnOrTable = TypeVar('ColumnOrTable', Column, Table)" in result
+    assert "def empty_like(input: ColumnOrTable) -> ColumnOrTable" in result
+    assert "input: ..." not in result
+    assert "-> ..." not in result


### PR DESCRIPTION
This PR adds fused type support. It passes all the tests added in #39. There are a few key pieces:
 - The tree traversal now recognizes fused type nodes.
 -  A pyx file's companion pxd file (foo.pxd for foo.pyx) is parsed before the pyx file to identify its fused types, which are then fed into the parsing of the pyx file.
 - The converter is made aware of fused types, and entities that could include fused types (function/method signatures) are updated to handle them appropriately.

The implementation includes a number of docstrings aiming to clarify the fact that this implementation is a bit clunky by virtue of being bolted on. A cleaner implementation would require more extensive surgery to make fused types a first-class entity within the typing system, particularly with respect to some of the oddities around handling memoryviews. It would also allow us to handle cross-module cimports of fused types. That change is out of scope for this PR, though.