### PR TITLE
Add exclude_pattern capability to CLI and StubgenPyx

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ stubgen-pyx . --output-dir stubs/
 # Convert a single .pyx file to a specific output path
 # (requires exactly one matching input file)
 stubgen-pyx . --file mymodule.pyx --output-file output/mymodule.pyi
+
+# Exclude certain files from conversion
+stubgen-pyx . --exclude-pattern "**/tests/**" --exclude-pattern "vendor/**"
 ```
 
 **Disable specific transformations:**
@@ -252,10 +255,7 @@ While mypy's `stubgen` can generate stubs for compiled extension modules through
 - Typed memoryviews (e.g. `double[:, :]` → `numpy.typing.NDArray[numpy.double]`)
 - Fixed-size C arrays (e.g. `char[100]` → `bytes`, `int[100][100]` → `list[list[int]]`)
 - Pointer-to-char declarations (`char *` → `bytes`)
-
-### Limitations
-
-- Fused types (generics) have basic support
+- Fused types (e.g. `FooOrBar` → `TypeVar('FooOrBar', Foo, Bar)` or `Foo | Bar` as appropriate)
 
 ## Configuration Options
 

--- a/stubgen_pyx/cli.py
+++ b/stubgen_pyx/cli.py
@@ -56,6 +56,14 @@ Examples:
     )
 
     parser.add_argument(
+        "--exclude-pattern",
+        help="Glob pattern for files to exclude from conversion. This option can be used multiple times (default: None)",
+        type=str,
+        nargs="*",
+        default=None,
+    )
+
+    parser.add_argument(
         "--output-dir",
         help="Directory to write .pyi files (default: same as source). "
         "This option cannot be used with option '--output-file'.",
@@ -211,7 +219,7 @@ def main() -> None:
 
     stubgen = StubgenPyx(config=config)
 
-    pyx_files = tuple(stubgen.resolve_glob(pyx_file_pattern))
+    pyx_files = tuple(stubgen.resolve_glob(pyx_file_pattern, args.exclude_pattern))
 
     # Validate no-files before single-file check to give clearer error messages
     if not pyx_files:

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from fnmatch import fnmatch
 import glob
 import logging
 import os
@@ -201,7 +202,7 @@ class StubgenPyx:
             exclude_patterns = [exclude_patterns]
 
         output = tuple(
-            f for f in gen if not any(f.full_match(p) for p in exclude_patterns)
+            f for f in gen if not any(fnmatch(str(f), str(p)) for p in exclude_patterns)
         )
         if output:
             logger.info(f"Found {len(output)} file(s) to convert")

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -167,7 +167,9 @@ class StubgenPyx:
 
         return module
 
-    def resolve_glob(self, pyx_file_pattern: str) -> Iterable[Path]:
+    def resolve_glob(
+        self, pyx_file_pattern: str, exclude_patterns: list[str] | str | None = None
+    ) -> tuple[Path, ...]:
         """Resolve given glob pattern.
 
         Args:
@@ -189,19 +191,28 @@ class StubgenPyx:
                 if Path(pxd_path).with_suffix("") not in pyx_stems:
                     file_paths.append(pxd_path)
 
-        if len(file_paths) == 0:
-            logger.warning(f"No files matched pattern: {pyx_file_pattern}")
-        else:
-            logger.info(f"Found {len(file_paths)} file(s) to convert")
-
         unique_paths = list(dict.fromkeys(file_paths))
-        return (Path(p) for p in unique_paths)
+        gen = (Path(p) for p in unique_paths)
+
+        if not exclude_patterns:
+            return tuple(gen)
+
+        if isinstance(exclude_patterns, str):
+            exclude_patterns = [exclude_patterns]
+
+        output = tuple(
+            f for f in gen if not any(f.full_match(p) for p in exclude_patterns)
+        )
+        if output:
+            logger.info(f"Found {len(output)} file(s) to convert")
+        return output
 
     def convert_glob(
         self,
         pyx_file_pattern: str,
         output_dir: Path | None = None,
         dry_run: bool = False,
+        exclude_patterns: list[str] | str | None = None,
     ) -> list[ConversionResult]:
         """Convert multiple .pyx files matching a glob pattern.
 
@@ -214,7 +225,14 @@ class StubgenPyx:
         Returns:
             List of ConversionResult objects with status for each file.
         """
-        pyx_files = self.resolve_glob(pyx_file_pattern)
+        pyx_files = self.resolve_glob(
+            pyx_file_pattern, exclude_patterns=exclude_patterns
+        )
+
+        if not pyx_files:
+            logger.warning("No files found to convert")
+            return []
+
         return self.convert_multiple_files(
             pyx_files, output_dir=output_dir, dry_run=dry_run
         )

--- a/stubgen_pyx/stubgen.py
+++ b/stubgen_pyx/stubgen.py
@@ -202,7 +202,12 @@ class StubgenPyx:
             exclude_patterns = [exclude_patterns]
 
         output = tuple(
-            f for f in gen if not any(fnmatch(str(f), str(p)) for p in exclude_patterns)
+            f
+            for f in gen
+            if not any(
+                fnmatch(str(f.as_posix()), p.replace("\\", "/"))
+                for p in exclude_patterns
+            )
         )
         if output:
             logger.info(f"Found {len(output)} file(s) to convert")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -558,3 +558,43 @@ def test_convert_single_file_in_output_dir_dry_run(temp_dir, temp_outdir):
     # Verify the .pyi file do not exist
     assert not pyx_file.with_suffix(".pyi").exists()
     assert not pyi_file.exists()
+
+
+def test_exclude_patterns(temp_dir):
+    """Test glob conversion with exclude patterns."""
+    pyx_file = temp_dir / "test1.pyx"
+    pyx_file.write_text("def func1(): pass")
+
+    stubgen = StubgenPyx()
+    result = stubgen.convert_glob(
+        str(temp_dir / "*.pyx"), exclude_patterns=[str(temp_dir / "**")]
+    )
+    assert len(result) == 0  # recursive exclude should work
+
+    result = stubgen.convert_glob(
+        str(temp_dir / "*.pyx"), exclude_patterns=[str(temp_dir / "test1.pyx")]
+    )
+    assert len(result) == 0  # explicit exclude should work
+
+    result = stubgen.convert_glob(str(temp_dir / "*.pyx"))
+    assert len(result) == 1  # no exclude should work
+
+    nested_dir = temp_dir / "nested"
+    nested_dir.mkdir()
+    nested_file = nested_dir / "test2.pyx"
+    nested_file.write_text("def func2(): pass")
+
+    result = stubgen.convert_glob(str(temp_dir / "**" / "*.pyx"))
+    assert len(result) == 2  # recursive glob without exclude matches both files
+
+    result = stubgen.convert_glob(
+        str(temp_dir / "**" / "*.pyx"),
+        exclude_patterns=[str(temp_dir / "nested" / "*")],
+    )
+    assert len(result) == 1  # explicit exclude should work
+
+    result = stubgen.convert_glob(
+        str(temp_dir / "**" / "*.pyx"),
+        exclude_patterns=[str(temp_dir / "test1.pyx"), str(temp_dir / "nested" / "*")],
+    )
+    assert len(result) == 0  # multiple excludes should be additive

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -579,6 +579,11 @@ def test_exclude_patterns(temp_dir):
     result = stubgen.convert_glob(str(temp_dir / "*.pyx"))
     assert len(result) == 1  # no exclude should work
 
+    result = stubgen.convert_glob(
+        str(temp_dir / "*.pyx"), exclude_patterns=str(temp_dir / "test1.pyx")
+    )
+    assert len(result) == 0  # passing a single exclude should work
+
     nested_dir = temp_dir / "nested"
     nested_dir.mkdir()
     nested_file = nested_dir / "test2.pyx"


### PR DESCRIPTION
Fixes #37 

This allows for the exclusion of specific paths using `fnmatch.fnmatch` during stub generation. This normalizes path separators to posix. Therefore, the following will work even if the user provides mixed path separators:

```bash
stubgen-pyx tests/ --exclude-pattern tests\**/*.pyx
```