### PR TITLE
Remove overload implementations from generated stubs

### DIFF
--- a/stubgen_pyx/postprocessing/overload_singledispatch.py
+++ b/stubgen_pyx/postprocessing/overload_singledispatch.py
@@ -7,6 +7,8 @@ import copy
 import warnings
 from dataclasses import dataclass
 
+from .utils import dotted_name
+
 
 class SingledispatchStubError(ValueError):
     """Raised when a @singledispatch group in the input is invalid Python.
@@ -310,13 +312,4 @@ def _emit_group(
 
 
 def _is_singledispatch(node: ast.expr) -> bool:
-    return _dotted_name(node).split(".")[-1] == "singledispatch"
-
-
-def _dotted_name(node: ast.expr) -> str:
-    if isinstance(node, ast.Name):
-        return node.id
-    if isinstance(node, ast.Attribute):
-        prefix = _dotted_name(node.value)
-        return f"{prefix}.{node.attr}" if prefix else node.attr
-    return ""
+    return dotted_name(node).split(".")[-1] == "singledispatch"

--- a/stubgen_pyx/postprocessing/pipeline.py
+++ b/stubgen_pyx/postprocessing/pipeline.py
@@ -17,6 +17,7 @@ from .deduplicate_imports import _DuplicateImportRemover
 from .normalize_member_spacing import normalize_member_spacing
 from .normalize_names import _NameNormalizer
 from .remove_identity_assignment import remove_identity_assignment
+from .remove_overload_implementations import remove_overload_implementations
 from .sort_imports import sort_imports
 from .trim_imports import _UnusedImportRemover
 from .trim_not_defined import trim_not_defined
@@ -69,6 +70,10 @@ def _ast_transforms(
         tree = _NameNormalizer(extra_translations=extra_translations or {}).visit(tree)
 
     tree = remove_identity_assignment(tree)
+
+    # Runs before import trimming so that imports which only the dropped
+    # implementation referenced are then seen as unused.
+    tree = remove_overload_implementations(tree)
 
     if config.trim_not_defined:
         trim_not_defined(tree)

--- a/stubgen_pyx/postprocessing/remove_overload_implementations.py
+++ b/stubgen_pyx/postprocessing/remove_overload_implementations.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import ast
 
+from .utils import dotted_name
+
 _FUNCTION_DEFS = (ast.FunctionDef, ast.AsyncFunctionDef)
 
 
@@ -80,14 +82,4 @@ def _has_overload_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) -> boo
 
 def _is_overload(node: ast.expr) -> bool:
     """Recognize ``overload`` and dotted spellings such as ``typing.overload``."""
-    return _dotted_name(node).split(".")[-1] == "overload"
-
-
-def _dotted_name(node: ast.expr) -> str:
-    """Return the dotted name of an expression, or ``""`` if it has none."""
-    if isinstance(node, ast.Name):
-        return node.id
-    if isinstance(node, ast.Attribute):
-        prefix = _dotted_name(node.value)
-        return f"{prefix}.{node.attr}" if prefix else node.attr
-    return ""
+    return dotted_name(node).split(".")[-1] == "overload"

--- a/stubgen_pyx/postprocessing/remove_overload_implementations.py
+++ b/stubgen_pyx/postprocessing/remove_overload_implementations.py
@@ -1,0 +1,93 @@
+"""Removes the implementation that accompanies ``@overload`` declarations.
+
+In a regular module, a series of ``@overload`` declarations must be followed by
+exactly one undecorated implementation, so a ``.pyx`` source has to provide it.
+Stub files are exempt from that rule, and mypy rejects a stub that carries the
+implementation::
+
+    example.pyi:11: error: An implementation for an overloaded function is not
+    allowed in a stub file  [misc]
+
+The declarations describe the entire signature, so the implementation adds
+nothing to the stub. mypy's own ``stubgen`` drops it as well, docstring
+included.
+"""
+
+from __future__ import annotations
+
+import ast
+
+_FUNCTION_DEFS = (ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def remove_overload_implementations(tree: ast.AST) -> ast.AST:
+    """Remove implementations of ``@overload``-declared functions from an AST.
+
+    A definition is removed when it carries no ``@overload`` decorator and at
+    least one same-named ``@overload`` definition is present in the same scope.
+    The scopes considered are the module body and each class body, so an
+    unrelated function of the same name in another scope is never affected.
+
+    Args:
+        tree: The AST to process.
+
+    Returns:
+        Transformed AST without overload implementations.
+    """
+    return _OverloadImplementationRemover().visit(tree)
+
+
+class _OverloadImplementationRemover(ast.NodeTransformer):
+    """Removes implementations that accompany ``@overload`` declarations."""
+
+    def visit_Module(self, node: ast.Module) -> ast.AST:
+        """Process the module scope."""
+        return self._process_scope(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:
+        """Process a class scope."""
+        return self._process_scope(node)
+
+    def _process_scope(self, node: ast.Module | ast.ClassDef) -> ast.AST:
+        """Remove overload implementations from a single scope."""
+        self.generic_visit(node)  # Nested classes hold a scope of their own.
+
+        overloaded = {
+            stmt.name
+            for stmt in node.body
+            if isinstance(stmt, _FUNCTION_DEFS) and _has_overload_decorator(stmt)
+        }
+        if not overloaded:
+            return node
+
+        # A declaration always survives, so the body cannot become empty.
+        node.body = [
+            stmt
+            for stmt in node.body
+            if not (
+                isinstance(stmt, _FUNCTION_DEFS)
+                and stmt.name in overloaded
+                and not _has_overload_decorator(stmt)
+            )
+        ]
+        return node
+
+
+def _has_overload_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Report whether a definition carries an ``@overload`` decorator."""
+    return any(_is_overload(decorator) for decorator in node.decorator_list)
+
+
+def _is_overload(node: ast.expr) -> bool:
+    """Recognize ``overload`` and dotted spellings such as ``typing.overload``."""
+    return _dotted_name(node).split(".")[-1] == "overload"
+
+
+def _dotted_name(node: ast.expr) -> str:
+    """Return the dotted name of an expression, or ``""`` if it has none."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""

--- a/stubgen_pyx/postprocessing/utils.py
+++ b/stubgen_pyx/postprocessing/utils.py
@@ -1,0 +1,15 @@
+"""
+Shared postprocessing utilities.
+"""
+
+import ast
+
+
+def dotted_name(node: ast.expr) -> str:
+    """Return the dotted name of an expression, or ``""`` if it has none."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""

--- a/tests/test_remove_overload_implementations.py
+++ b/tests/test_remove_overload_implementations.py
@@ -1,0 +1,225 @@
+"""Tests for the remove_overload_implementations postprocessing module."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+
+from stubgen_pyx import StubgenPyx
+from stubgen_pyx.config import StubgenPyxConfig
+from stubgen_pyx.postprocessing.pipeline import postprocessing_pipeline
+from stubgen_pyx.postprocessing.remove_overload_implementations import (
+    remove_overload_implementations,
+)
+
+
+def _transform(code: str) -> ast.Module:
+    """Apply the pass to a module and return the resulting tree."""
+    tree = remove_overload_implementations(ast.parse(textwrap.dedent(code)))
+    assert isinstance(tree, ast.Module)
+    return tree
+
+
+def _functions(body: list[ast.stmt]) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return the function definitions of a body, in order."""
+    return [
+        stmt
+        for stmt in body
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+
+
+def _class(tree: ast.Module, name: str) -> ast.ClassDef:
+    """Return the class of the given name from a module body."""
+    for stmt in tree.body:
+        if isinstance(stmt, ast.ClassDef) and stmt.name == name:
+            return stmt
+    raise AssertionError(f"class {name!r} not found")
+
+
+class TestRemoveOverloadImplementations:
+    """Test the removal of implementations declared with ``@overload``."""
+
+    def test_module_level_implementation_removed(self):
+        """A module-level implementation is removed, declarations are kept."""
+        tree = _transform("""
+            from typing import overload
+
+            @overload
+            def f(x: int) -> int: ...
+            @overload
+            def f(x: str) -> str: ...
+            def f(x):
+                return x
+            """)
+        functions = _functions(tree.body)
+        assert len(functions) == 2
+        assert [f.returns.id for f in functions] == ["int", "str"]
+
+    def test_method_implementation_removed(self):
+        """A method implementation is removed from a class body."""
+        tree = _transform("""
+            from typing import overload
+
+            class A:
+                @overload
+                def __getitem__(self, x: int) -> int: ...
+                @overload
+                def __getitem__(self, x: str) -> str: ...
+                def __getitem__(self, x): ...
+            """)
+        assert len(_functions(_class(tree, "A").body)) == 2
+
+    def test_dotted_decorator_recognized(self):
+        """``typing.overload`` counts as an overload declaration."""
+        tree = _transform("""
+            import typing
+
+            @typing.overload
+            def f(x: int) -> int: ...
+            @typing.overload
+            def f(x: str) -> str: ...
+            def f(x): ...
+            """)
+        assert len(_functions(tree.body)) == 2
+
+    def test_async_implementation_removed(self):
+        """An ``async def`` implementation is removed like a plain one."""
+        tree = _transform("""
+            from typing import overload
+
+            @overload
+            async def f(x: int) -> int: ...
+            @overload
+            async def f(x: str) -> str: ...
+            async def f(x): ...
+            """)
+        assert len(_functions(tree.body)) == 2
+
+    def test_decorated_implementation_removed(self):
+        """An implementation with other decorators is still removed."""
+        tree = _transform("""
+            from typing import overload
+
+            class A:
+                @overload
+                @staticmethod
+                def f(x: int) -> int: ...
+                @overload
+                @staticmethod
+                def f(x: str) -> str: ...
+                @staticmethod
+                def f(x): ...
+            """)
+        assert len(_functions(_class(tree, "A").body)) == 2
+
+    def test_function_without_overloads_kept(self):
+        """A definition with no overload declarations is left alone."""
+        tree = _transform("""
+            def f(x): ...
+            def g(x): ...
+            """)
+        assert [f.name for f in _functions(tree.body)] == ["f", "g"]
+
+    def test_scopes_are_independent(self):
+        """An overload in a class does not affect a module-level function."""
+        tree = _transform("""
+            from typing import overload
+
+            class A:
+                @overload
+                def f(self, x: int) -> int: ...
+                @overload
+                def f(self, x: str) -> str: ...
+                def f(self, x): ...
+
+            def f(x): ...
+            """)
+        assert [f.name for f in _functions(tree.body)] == ["f"]
+        assert len(_functions(_class(tree, "A").body)) == 2
+
+    def test_nested_class_processed(self):
+        """A class body nested in another class is processed as its own scope."""
+        tree = _transform("""
+            from typing import overload
+
+            class Outer:
+                class Inner:
+                    @overload
+                    def f(self, x: int) -> int: ...
+                    @overload
+                    def f(self, x: str) -> str: ...
+                    def f(self, x): ...
+            """)
+        inner = _class(_class(tree, "Outer"), "Inner")
+        assert len(_functions(inner.body)) == 2
+
+    def test_surrounding_statements_preserved(self):
+        """Statements other than the implementation keep their order."""
+        tree = _transform("""
+            from typing import overload
+
+            VERSION: str
+
+            @overload
+            def f(x: int) -> int: ...
+            @overload
+            def f(x: str) -> str: ...
+            def f(x): ...
+
+            class A: ...
+            """)
+        assert [type(stmt).__name__ for stmt in tree.body] == [
+            "ImportFrom",
+            "AnnAssign",
+            "FunctionDef",
+            "FunctionDef",
+            "ClassDef",
+        ]
+
+
+class TestRemoveOverloadImplementationsInPipeline:
+    """Test the pass as part of the postprocessing pipeline."""
+
+    def test_generated_stub_omits_implementation(self):
+        """Overloads written in a .pyx reach the stub without the body."""
+        pyi = StubgenPyx(
+            StubgenPyxConfig(exclude_attribution=True, sort_imports=False)
+        ).convert_str(
+            textwrap.dedent("""
+                from typing import overload
+
+                cdef class A:
+                    @overload
+                    def __getitem__(self, x: int) -> int: ...
+                    @overload
+                    def __getitem__(self, x: str) -> str: ...
+                    def __getitem__(self, x):
+                        return x
+                """)
+        )
+        assert pyi == textwrap.dedent("""\
+            from typing import overload
+            class A:
+                @overload
+                def __getitem__(self, x: int) -> int: ...
+                @overload
+                def __getitem__(self, x: str) -> str: ...
+            """)
+
+    def test_import_used_only_by_implementation_is_trimmed(self):
+        """Removal happens before import trimming, so stale imports go away."""
+        pyi = postprocessing_pipeline(
+            textwrap.dedent("""\
+                from typing import Any, overload
+
+                @overload
+                def f(x: int) -> int: ...
+                @overload
+                def f(x: str) -> str: ...
+                def f(x: Any) -> Any: ...
+                """),
+            StubgenPyxConfig(exclude_attribution=True),
+        )
+        assert "Any" not in pyi
+        assert "overload" in pyi


### PR DESCRIPTION
Fixes #48.

## Problem

Decorator passthrough already carries `@overload` declarations from a `.pyx` into the generated stub, which is the only way to express an argument-dependent return type for a compiled extension. The source must also provide the undecorated implementation, because that is what Cython binds at run time. A stub file, however, must not carry it, so mypy rejects the generated output:

```
example.pyi:11: error: An implementation for an overloaded function is not allowed in a stub file  [misc]
```

That makes overloads unusable for any project that type-checks its generated stubs.

## Change

A new postprocessing pass, `remove_overload_implementations`, drops a definition when it carries no `@overload` decorator and at least one same-named `@overload` definition is present in the same scope. The scopes considered are the module body and each class body, so an unrelated function of the same name elsewhere is never affected. The declarations describe the entire signature, so nothing is lost. This matches what mypy's own `stubgen` emits for equivalent pure-Python input.

The pass is unconditional, in the same spirit as `remove_identity_assignment` and `collapse_funcdefs`, since a stub that a type checker rejects is not a useful output. It runs directly before import trimming, so an import that only the discarded implementation referenced is then correctly seen as unused.

Two behaviours worth flagging for review:

- The implementation's docstring goes with it. mypy's `stubgen` does the same, even under `--include-docstrings`. Attaching it to the first declaration instead would be easy if you prefer that.
- Decorator recognition covers `overload` and dotted spellings such as `typing.overload`, but not an `import as` alias. This matches the `_dotted_name` helper in #46; if either change lands first, the two can share one helper.

## Verification

- The full suite passes, 444 tests against a 433 baseline, and `ruff check` plus `ruff format --check` are clean.
- The reproducer from #48 now passes mypy 2.3.0 with `Success: no issues found`, and mypy and pyright 1.1.411 both resolve the overloaded `__getitem__` correctly.
- The pass is inert without `@overload`. Generating 49 stubs from a real Cython package with released 0.2.17 and with this branch gives byte-identical trees under `diff -r`.

New tests cover module and class scopes, dotted decorators, `async def`, an implementation carrying `@staticmethod`, definitions with no overload declarations, scope independence, nested classes, statement order, the end-to-end `cdef class` case, and the import-trimming interaction.

I left `pyproject.toml` alone, since version increases look like separate release commits.
