### PR TITLE
feat: unquote string annotations in generated stubs

### DIFF
--- a/stubgen_pyx/postprocessing/pipeline.py
+++ b/stubgen_pyx/postprocessing/pipeline.py
@@ -22,6 +22,7 @@ from .remove_overload_implementations import remove_overload_implementations
 from .sort_imports import sort_imports
 from .trim_imports import _UnusedImportRemover
 from .trim_not_defined import trim_not_defined
+from .unquote_annotations import unquote_annotations
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,8 @@ def _ast_transforms(
         trim_not_defined(tree)
 
     tree = overload_singledispatch(tree)
+
+    tree = unquote_annotations(tree)
 
     if config.trim_imports:
         used_names = collect_names(tree)

--- a/stubgen_pyx/postprocessing/unquote_annotations.py
+++ b/stubgen_pyx/postprocessing/unquote_annotations.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import ast
+
+
+def unquote_annotations(tree: ast.AST) -> ast.AST:
+    return ast.fix_missing_locations(_AnnotationUnquoter().visit(tree))
+
+
+class _AnnotationUnquoter(ast.NodeTransformer):
+    @staticmethod
+    def _unquote(annotation: ast.expr | None) -> ast.expr | None:
+        if not (
+            isinstance(annotation, ast.Constant) and isinstance(annotation.value, str)
+        ):
+            return annotation
+
+        try:
+            parsed = ast.parse(annotation.value, mode="eval").body
+        except SyntaxError:
+            return annotation
+
+        return ast.copy_location(parsed, annotation)
+
+    def visit_arg(self, node: ast.arg) -> ast.arg:
+        node.annotation = self._unquote(node.annotation)
+        return node
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> ast.AnnAssign:
+        unquoted = self._unquote(node.annotation)
+        if unquoted is not None:
+            node.annotation = unquoted
+        self.generic_visit(node)
+        return node
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
+        node.returns = self._unquote(node.returns)
+        self.generic_visit(node)
+        return node
+
+    def visit_AsyncFunctionDef(
+        self, node: ast.AsyncFunctionDef
+    ) -> ast.AsyncFunctionDef:
+        node.returns = self._unquote(node.returns)
+        self.generic_visit(node)
+        return node

--- a/tests/test_unquote_annotations.py
+++ b/tests/test_unquote_annotations.py
@@ -28,10 +28,13 @@ CASES = [
     Case(
         id="quoted_param_annotation_unquoted",
         pyx="""\
+cdef class Foo:
+    pass
+
 cpdef void f(x: 'Foo | None'):
     pass
 """,
-        expected="def f(x: Foo | None) -> None: ...\n",
+        expected="class Foo: ...\n\ndef f(x: Foo | None) -> None: ...\n",
     ),
     Case(
         id="quoted_return_annotation_unquoted",
@@ -70,19 +73,31 @@ cpdef void f(x: 'not valid python >>>'):
     Case(
         id="multiple_quoted_params_all_unquoted",
         pyx="""\
+cdef class Foo:
+    pass
+
+cdef class Bar:
+    pass
+
+cdef class Baz:
+    pass
+
 cpdef void f(x: 'Foo | None', y: 'Bar | Baz'):
     pass
 """,
-        expected="def f(x: Foo | None, y: Bar | Baz) -> None: ...\n",
+        expected="class Foo: ...\n\nclass Bar: ...\n\nclass Baz: ...\n\ndef f(x: Foo | None, y: Bar | Baz) -> None: ...\n",
     ),
     Case(
         id="class_method_quoted_annotation_unquoted",
         pyx="""\
+cdef class Foo:
+    pass
+
 cdef class Ops:
     cpdef void f(self, x: 'Foo | None'):
         pass
 """,
-        expected="class Ops:\n    def f(self, x: Foo | None) -> None: ...\n",
+        expected="class Foo: ...\n\nclass Ops:\n    def f(self, x: Foo | None) -> None: ...\n",
     ),
     Case(
         id="module_level_annassign_unquoted",
@@ -105,10 +120,13 @@ async def f() -> 'list[int]':
     Case(
         id="async_function_quoted_param_unquoted",
         pyx="""\
+cdef class Foo:
+    pass
+
 async def f(x: 'Foo | None'):
     pass
 """,
-        expected="async def f(x: Foo | None): ...\n",
+        expected="class Foo: ...\n\nasync def f(x: Foo | None): ...\n",
     ),
     Case(
         id="class_attribute_quoted_annotation_unquoted",

--- a/tests/test_unquote_annotations.py
+++ b/tests/test_unquote_annotations.py
@@ -1,0 +1,132 @@
+"""Tests for annotation-unquoting, exercised through the public API.
+
+Each ``Case`` feeds Cython source into :meth:`StubgenPyx.convert_str` and
+asserts on the final ``.pyi`` output. The scenarios cover the four
+annotation surfaces the pass touches (function args, return types,
+``AnnAssign`` targets, class methods) plus the guard on non-parseable
+strings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from stubgen_pyx import StubgenPyx
+from stubgen_pyx.config import StubgenPyxConfig
+
+
+@dataclass(frozen=True)
+class Case:
+    id: str
+    pyx: str
+    expected: str
+
+
+CASES = [
+    Case(
+        id="quoted_param_annotation_unquoted",
+        pyx="""\
+cpdef void f(x: 'Foo | None'):
+    pass
+""",
+        expected="def f(x: Foo | None) -> None: ...\n",
+    ),
+    Case(
+        id="quoted_return_annotation_unquoted",
+        pyx="""\
+def f() -> 'list[int]':
+    pass
+""",
+        expected="def f() -> list[int]: ...\n",
+    ),
+    Case(
+        id="quoted_nested_generic_return_unquoted",
+        pyx="""\
+def f() -> 'dict[str, list[int]]':
+    pass
+""",
+        expected="def f() -> dict[str, list[int]]: ...\n",
+    ),
+    Case(
+        id="quoted_annotation_preserves_cimport",
+        pyx="""\
+from some_mod cimport Foo
+
+cpdef void f(x: 'Foo | None'):
+    pass
+""",
+        expected="from some_mod import Foo\ndef f(x: Foo | None) -> None: ...\n",
+    ),
+    Case(
+        id="non_parseable_annotation_stays_quoted",
+        pyx="""\
+cpdef void f(x: 'not valid python >>>'):
+    pass
+""",
+        expected="def f(x: 'not valid python >>>') -> None: ...\n",
+    ),
+    Case(
+        id="multiple_quoted_params_all_unquoted",
+        pyx="""\
+cpdef void f(x: 'Foo | None', y: 'Bar | Baz'):
+    pass
+""",
+        expected="def f(x: Foo | None, y: Bar | Baz) -> None: ...\n",
+    ),
+    Case(
+        id="class_method_quoted_annotation_unquoted",
+        pyx="""\
+cdef class Ops:
+    cpdef void f(self, x: 'Foo | None'):
+        pass
+""",
+        expected="class Ops:\n    def f(self, x: Foo | None) -> None: ...\n",
+    ),
+    Case(
+        id="module_level_annassign_unquoted",
+        pyx="""\
+cdef class Foo:
+    pass
+
+x: 'Foo | None'
+""",
+        expected="x: Foo | None\n\nclass Foo: ...\n",
+    ),
+    Case(
+        id="async_function_quoted_return_unquoted",
+        pyx="""\
+async def f() -> 'list[int]':
+    pass
+""",
+        expected="async def f() -> list[int]: ...\n",
+    ),
+    Case(
+        id="async_function_quoted_param_unquoted",
+        pyx="""\
+async def f(x: 'Foo | None'):
+    pass
+""",
+        expected="async def f(x: Foo | None): ...\n",
+    ),
+    Case(
+        id="class_attribute_quoted_annotation_unquoted",
+        pyx="""\
+cdef class Foo:
+    x: 'int | None'
+""",
+        expected="class Foo:\n    x: int | None\n",
+    ),
+]
+
+
+def _stubgen() -> StubgenPyx:
+    return StubgenPyx(StubgenPyxConfig(exclude_attribution=True, sort_imports=False))
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
+def test_unquote_annotations_via_public_api(case: Case):
+    result = _stubgen().convert_str(case.pyx)
+
+    assert result == case.expected


### PR DESCRIPTION
Closes #36.

Adds a post-processing pass that unquotes string-form annotations (`ast.Constant[str]`) in the generated `.pyi` when the string is a parseable Python expression. Non-parseable strings are left alone.

## Motivation

Cython emits many annotations as string forwards (`"Foo | None"`, `"list[int]"`, etc.). In a stub file this is unnecessary — stubs are never executed, so there's no runtime forward-reference problem. Leaving them quoted:

- forces every consumer (mypy, pyright, IDE, tooling) to re-parse strings
- hides real annotations from surface-level `grep`/tooling
- diverges from the shape a hand-written stub would take

## What it does

New AST transform `unquote_annotations`, run unconditionally in the post-processing pipeline. Handles all four annotation surfaces:

| Node                | Field                |
|---------------------|----------------------|
| `ast.arg`           | `annotation`         |
| `ast.AnnAssign`     | `annotation`         |
| `ast.FunctionDef`   | `returns`            |
| `ast.AsyncFunctionDef` | `returns`         |

For each string-constant annotation, tries `ast.parse(value, mode="eval")`. On success: replace with the parsed expression (locations copied from the original constant). On `SyntaxError`: leave the string in place — the generator or the user meant something unparseable, and silently stripping quotes would produce invalid code.

Runs after `remove_overload_implementations` / `trim_not_defined` and before `trim_imports`, so newly-visible identifiers inside the unquoted expressions are considered when deciding which imports are unused.
