### PR TITLE
Fix #41: read included files as UTF-8

### DIFF
--- a/stubgen_pyx/parsing/file_parsing.py
+++ b/stubgen_pyx/parsing/file_parsing.py
@@ -76,7 +76,7 @@ def file_parsing_preprocess(source: Path, code: str) -> str:
 
 def _read_file_fallback(path: Path, fallback: str) -> str:
     try:
-        return path.read_text()
+        return path.read_text(encoding="utf-8")
     except (UnicodeDecodeError, FileNotFoundError):
         logger.warning(f"Could not read file: {path}")
         return fallback

--- a/tests/test_file_parsing.py
+++ b/tests/test_file_parsing.py
@@ -83,6 +83,31 @@ class TestGetIncludes:
             result = file_parsing._expand_includes(source_file, code)
             assert "included_func" in result
 
+    def test_expand_includes_reads_included_file_as_utf8(self):
+        """Included files must be read as UTF-8 regardless of platform locale.
+
+        Regression test for https://github.com/jon-edward/stubgen-pyx/issues/41:
+        `_read_file_fallback` used `Path.read_text()` with no explicit
+        encoding, which falls back to the platform's default encoding (e.g.
+        cp1252 on Windows) rather than UTF-8. Non-ASCII content (e.g. "TM",
+        the trademark sign) in an `include`d file would then come out
+        mojibake'd once round-tripped through that encoding.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            include_file = tmppath / "include.pyx"
+            include_file.write_text(
+                'def func():\n    """Kepler™ or newer."""\n', encoding="utf-8"
+            )
+
+            source_file = tmppath / "source.pyx"
+            source_file.write_text("", encoding="utf-8")
+
+            code = 'include "include.pyx"'
+            result = file_parsing._expand_includes(source_file, code)
+            assert "Kepler™" in result
+
     def test_expand_includes_nonexistent_include(self):
         """Test that nonexistent includes are ignored."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Fixes #41, which was closed by explicitly passing `encoding="utf-8"` to
the top-level `.pyx`/`.pxd` reads and the `.pyi` write in `stubgen.py`.
That fix missed one remaining spot: `_read_file_fallback` in
`file_parsing.py`, used to expand Cython `include "foo.pxi"` directives,
still calls `Path.read_text()` with no explicit encoding. That falls
back to the platform's default encoding (`locale.getpreferredencoding()`),
which is typically `cp1252` on Windows rather than UTF-8.

Any non-ASCII character (e.g. "™", "μ") in an `include`d file gets
misdecoded under `cp1252` and then re-encoded as UTF-8 when the stub is
written, producing mojibake like:

```
Kepler™  ->  Keplerâ„¢
```

This only surfaces for modules that use `include`, since the top-level
`.pyx`/`.pxd` reads were already fixed. Discovered while regenerating
`.pyi` stubs for [NVIDIA/cuda-python](https://github.com/NVIDIA/cuda-python)
on Windows CI - `cuda_core`'s `_device.pyx` pulls in ~17 `.pxi` files via
`include`, several of which have docstrings with non-ASCII text.

## Fix

One-line change: pass `encoding="utf-8"` to the `Path.read_text()` call
in `_read_file_fallback`, matching every other file read/write in the
codebase.

## Test plan

- [x] Added a regression test (`test_expand_includes_reads_included_file_as_utf8`)
      that writes a UTF-8-encoded include file with a non-ASCII character
      and asserts it survives `_expand_includes` unchanged. This test
      wouldn't have failed on Linux before the fix (UTF-8 is the default
      locale there), but `tests.yml`'s `windows-latest` matrix leg would
      have caught the regression.
- [x] `pytest` (530 passed, 1 new)
- [x] `ruff check` / `ruff format --check` clean