### PR TITLE
Handle unhashable class assignments in generated stubs

### DIFF
--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -267,7 +267,9 @@ class Converter:
         ]
 
         conv_assignments = (
-            self.convert_assignment(assignment, source_code)
+            self.convert_assignment(
+                assignment, source_code, in_class=visitor.in_class
+            )
             for assignment in visitor.assignments
         )
 
@@ -409,7 +411,11 @@ class Converter:
         )
 
     def convert_assignment(
-        self, assignment: Nodes.AssignmentNode | Nodes.ExprStatNode, source_code: str
+        self,
+        assignment: Nodes.AssignmentNode | Nodes.ExprStatNode,
+        source_code: str,
+        *,
+        in_class: bool = False,
     ) -> PyiAssignment | None:
         """Convert an assignment node to PyiAssignment, extracting type annotations."""
         out_assignment_str: str | None = None
@@ -461,6 +467,9 @@ class Converter:
             _logger.debug("Could not parse assignment source: %r", out_assignment_str)
             return None
 
+        if in_class and _is_unhashable_hash_assignment(node.body[0]):
+            out_assignment_str = "__hash__ = None  # type: ignore[assignment]"
+
         return PyiAssignment(out_assignment_str)
 
     def convert_enum(self, node: Nodes.CEnumDefNode) -> PyiEnum | PyiAssignment:
@@ -478,6 +487,17 @@ def _is_cxx_cimport(raw: str) -> bool:
 
 def _is_cython_import(raw: str) -> bool:
     return bool(_CYTHON_FROM_IMPORT_RE.search(raw) or _CYTHON_IMPORT_RE.search(raw))
+
+
+def _is_unhashable_hash_assignment(node: ast.stmt) -> bool:
+    return (
+        isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "__hash__"
+        and isinstance(node.value, ast.Constant)
+        and node.value.value is None
+    )
 
 
 def _restore_fused_memoryview_annotations(

--- a/stubgen_pyx/conversion/converter.py
+++ b/stubgen_pyx/conversion/converter.py
@@ -267,9 +267,7 @@ class Converter:
         ]
 
         conv_assignments = (
-            self.convert_assignment(
-                assignment, source_code, in_class=visitor.in_class
-            )
+            self.convert_assignment(assignment, source_code, in_class=visitor.in_class)
             for assignment in visitor.assignments
         )
 

--- a/tests/fixtures/unhashable.pyx
+++ b/tests/fixtures/unhashable.pyx
@@ -1,0 +1,2 @@
+cdef class UnhashableThing:
+    __hash__ = None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -512,6 +512,25 @@ def shifted(it: AbstractSet[Any]) -> Any:  # type: ignore[override,misc]
     assert "# type: ignore[override,misc]" in shifted_line
 
 
+def test_unhashable_class_assignment_is_mypy_compatible(temp_dir):
+    """Class-level ``__hash__ = None`` needs an ignore in pyi files."""
+    pyx_file = temp_dir / "test.pyx"
+    pyx_file.write_text(
+        """
+__hash__ = None
+
+cdef class UnhashableThing:
+    __hash__ = None
+"""
+    )
+
+    stubgen = StubgenPyx()
+    result = stubgen.convert_str(pyx_file.read_text(), pyx_path=pyx_file)
+
+    assert "\n__hash__ = None\n" in result
+    assert "    __hash__ = None # type: ignore[assignment]" in result
+
+
 def test_conversion_succeeds_with_comments_inside_brackets(temp_dir):
     """A `#` comment inside a bracketed expression is terminated by its
     newline. Stub generation must not collapse that newline away, or the


### PR DESCRIPTION
## Summary

- Emit `__hash__ = None # type: ignore[assignment]` for class-level `__hash__ = None` assignments so generated stubs remain mypy-compatible while preserving the unhashable-class contract.
- Keep module-level `__hash__ = None` unchanged.
- Add a smoke fixture that reproduces the mypy failure from #76 and an integration assertion for the generated output.

Fixes #76.